### PR TITLE
Test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 __pycache__/
+.mypy_cache
 *.egg-info/
 **/*.pyc
 .cache
 examples/data
 .idea
+.coverage
 dist/*
 build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ install:
 cache:
 - pip
 script:
-- pytest -vx .
+- pytest -vx --cov=backpack/ .
+after_success:
+- coveralls
 notifications:
   email: false
   slack:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # BACKpropagation PACKage - a backpack for `PyTorch`
-[![Build Status](https://travis-ci.org/f-dangel/backpack.svg?branch=master)](https://travis-ci.org/f-dangel/backpack)
-[![Coverage Status](https://coveralls.io/repos/github/f-dangel/backpack/badge.svg)](https://coveralls.io/github/f-dangel/backpack)
+`master`: [![Build Status](https://travis-ci.org/f-dangel/backpack.svg?branch=master)](https://travis-ci.org/f-dangel/backpack)
+[![Coverage Status](https://coveralls.io/repos/github/f-dangel/backpack/badge.svg?branch=master)](https://coveralls.io/github/f-dangel/backpack)
 
+`development`: [![Build Status](https://travis-ci.org/f-dangel/backpack.svg?branch=development)](https://travis-ci.org/f-dangel/backpack)
+[![Coverage Status](https://coveralls.io/repos/github/f-dangel/backpack/badge.svg?branch=development)](https://coveralls.io/github/f-dangel/backpack)
 
 A backpack for PyTorch that extends the backward pass of feedforward networks to compute quantities beyond the gradient.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # BACKpropagation PACKage - a backpack for `PyTorch`
 [![Build Status](https://travis-ci.org/f-dangel/backpack.svg?branch=master)](https://travis-ci.org/f-dangel/backpack)
+[![Coverage Status](https://coveralls.io/repos/github/f-dangel/backpack/badge.svg)](https://coveralls.io/github/f-dangel/backpack)
 
 
 A backpack for PyTorch that extends the backward pass of feedforward networks to compute quantities beyond the gradient.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
+coveralls
 scipy
 pytest >= 4.5.0, < 5.0.0
 pytest-benchmark >= 3.2.2, < 4.0.0
+pytest-cov
 pytest-optional-tests >= 0.1.1


### PR DESCRIPTION
Add test coverage with [`coveralls`](https://coveralls.io/).

Coverage report from the command line:
```
pytest -vx --cov=backpack/ .
```