### PR TITLE
Batch l2 doc error

### DIFF
--- a/backpack/extensions/firstorder/batch_l2_grad/__init__.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/__init__.py
@@ -7,7 +7,7 @@ from . import linear, conv2d
 
 class BatchL2Grad(BackpropExtension):
     """
-    The L2 norm of individual gradients in the minibatch.
+    The squared L2 norm of individual gradients in the minibatch.
     Is only meaningful is the individual functions are independent (no batchnorm).
 
     Stores the output in :code:`batch_l2`

--- a/docs/rtd/extensions.html
+++ b/docs/rtd/extensions.html
@@ -168,7 +168,7 @@ is the shape of the gradient.</p>
 <dl class="function">
 <dt id="backpack.extensions.BatchL2Grad">
 <code class="sig-prename descclassname">backpack.extensions.</code><code class="sig-name descname">BatchL2Grad</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#backpack.extensions.BatchL2Grad" title="Permalink to this definition">¶</a></dt>
-<dd><p>The L2 norm of individual gradients in the minibatch.
+<dd><p>The squared L2 norm of individual gradients in the minibatch.
 Is only meaningful is the individual functions are independent (no batchnorm).</p>
 <p>Stores the output in <code class="code docutils literal notranslate"><span class="pre">batch_l2</span></code>
 as a vector of the size as the minibatch.</p>


### PR DESCRIPTION
Fix documentation of `BatchL2Grad`. The squared L2 norm of individual gradients is computed. Thanks @frhrdr for pointing out this problem