### PR TITLE
Hvp allow gradients

### DIFF
--- a/backpack/hessianfree/hvp.py
+++ b/backpack/hessianfree/hvp.py
@@ -3,7 +3,7 @@ import torch
 from .rop import R_op
 
 
-def hessian_vector_product(f, params, v, detach=True):
+def hessian_vector_product(f, params, v, grad_params=None, detach=True):
     """
     Multiplies the vector `v` with the Hessian,
     `v = H @ v`
@@ -29,11 +29,21 @@ def hessian_vector_product(f, params, v, detach=True):
         params: torch.Tensor or [torch.Tensor]
         v: torch.Tensor or [torch.Tensor]
             Shapes must match `params`
+        grad_params: torch.Tensor or [torch.Tensor], optional
+            Gradient of `f` w.r.t. `params`. If the gradients have already
+            been computed elsewhere, the first of two backpropagations can
+            be saved. `grad_params` must have been computed with
+            `create_graph = True` to not destroy the computation graph for
+            the second backward pass.
         detach: Bool, optional
             Whether to detach the output from the computation graph
             (default: True)
     """
-    df_dx = torch.autograd.grad(f, params, create_graph=True, retain_graph=True)
+    if grad_params is not None:
+        df_dx = tuple(grad_params)
+    else:
+        df_dx = torch.autograd.grad(f, params, create_graph=True, retain_graph=True)
+
     Hv = R_op(df_dx, params, v)
 
     if detach:

--- a/examples/example_hessian_matrix.py
+++ b/examples/example_hessian_matrix.py
@@ -2,6 +2,7 @@
 Compute the full Hessian matrix with automatic differentiation.
 Use Hessian-vector products for row-wise construction.
 """
+import time
 import torch
 from torch.nn import CrossEntropyLoss, Flatten, Linear, Sequential
 from torch.nn.utils.convert_parameters import parameters_to_vector
@@ -13,16 +14,18 @@ from backpack.utils.examples import load_mnist_data
 B = 4
 X, y = load_mnist_data(B)
 
-print("# Hessian matrix with automatic differentiation | B =", B)
-
 model = Sequential(Flatten(), Linear(784, 10),)
 lossfunc = CrossEntropyLoss()
+
+print("# 1) Hessian matrix with automatic differentiation | B =", B)
 
 loss = lossfunc(model(X), y)
 
 num_params = sum(p.numel() for p in model.parameters())
 hessian = torch.zeros(num_params, num_params)
 
+
+start = time.time()
 for i in range(num_params):
     # GGN-vector product with i.th unit vector yields the i.th row
     e_i = torch.zeros(num_params)
@@ -34,7 +37,41 @@ for i in range(num_params):
 
     hessian_i = parameters_to_vector(hessian_i_list)
     hessian[i, :] = hessian_i
+end = time.time()
 
 print("Model parameters: ", num_params)
 print("Hessian shape:    ", hessian.shape)
 print("Hessian:          ", hessian)
+print("Time [s]:         ", end - start)
+
+print("# 2) Hessian matrix with automatic differentiation (faster) | B =", B)
+print("# Save one backpropagation for each HVP by recycling gradients")
+
+loss = lossfunc(model(X), y)
+loss.backward(create_graph=True)
+
+grad_params = [p.grad for p in model.parameters()]
+
+num_params = sum(p.numel() for p in model.parameters())
+hessian = torch.zeros(num_params, num_params)
+
+start = time.time()
+for i in range(num_params):
+    # GGN-vector product with i.th unit vector yields the i.th row
+    e_i = torch.zeros(num_params)
+    e_i[i] = 1.0
+
+    # convert to model parameter shapes
+    e_i_list = vector_to_parameter_list(e_i, model.parameters())
+    hessian_i_list = hessian_vector_product(
+        loss, list(model.parameters()), e_i_list, grad_params=grad_params
+    )
+
+    hessian_i = parameters_to_vector(hessian_i_list)
+    hessian[i, :] = hessian_i
+end = time.time()
+
+print("Model parameters: ", num_params)
+print("Hessian shape:    ", hessian.shape)
+print("Hessian:          ", hessian)
+print("Time [s]:         ", end - start)

--- a/examples/example_hessian_vector_product.py
+++ b/examples/example_hessian_vector_product.py
@@ -55,3 +55,24 @@ print("Model parameters:                  ", num_params)
 print("flat vector shape:                 ", v_flat.shape)
 # individual gradient L2 norm
 print("flat Hessian-vector product shape: ", Hv_flat.shape)
+
+
+print("# 3) Using gradients to save one backward pass | B =", B)
+
+loss = lossfunc(model(X), y)
+# has to be called with create_graph=True
+loss.backward(create_graph=True)
+
+v = [torch.randn_like(p) for p in model.parameters()]
+params = list(model.parameters())
+grad_params = [p.grad for p in params]
+Hv = hessian_vector_product(loss, params, v, grad_params=grad_params)
+
+
+for (name, param), vec, Hvec in zip(model.named_parameters(), v, Hv):
+    print(name)
+    print(".grad.shape:                  ", param.grad.shape)
+    # vector
+    print("vector shape:                 ", vec.shape)
+    # Hessian-vector product
+    print("Hessian-vector product shape: ", Hvec.shape)


### PR DESCRIPTION
Add argument to pass gradients to the Hessian-vector product.

If the gradients of `f` with respect to `params` have already been computed from a `f.backward(create_graph=True)` call, they can be recycled.