### PR TITLE
Docstring standards

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,0 +1,4 @@
+[darglint]
+docstring_style = google
+# short, long, full
+strictness = full

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -51,3 +51,18 @@ jobs:
     - name: Run pydocstyle
       run: |
         make pydocstyle-check
+  darglint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        make install-lint
+    - name: Run darglint
+      run: |
+        make darglint-check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,3 +36,18 @@ jobs:
     - name: Run black
       run: |
         make black-check
+  pydocstyle:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        make install-lint
+    - name: Run pydocstyle
+      run: |
+        make pydocstyle-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
         flake8-bugbear,
         flake8-comprehensions,
       ]
+- repo: https://github.com/pycqa/pydocstyle
+  rev: 5.0.2
+  hooks:
+  - id: pydocstyle
+    args:
+    - --count

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,29 @@ repos:
 - repo: https://github.com/psf/black
   rev: stable
   hooks:
-    - id: black
-      args: [--config=black.toml]
+  - id: black
+    args: [--config=black.toml]
 - repo: https://gitlab.com/pycqa/flake8
   rev: '3.7.9'
   hooks:
-    - id: flake8
-      additional_dependencies: [
-        mccabe,
-        pycodestyle,
-        pyflakes,
-        pep8-naming,
-        flake8-bugbear,
-        flake8-comprehensions,
-      ]
+  - id: flake8
+    additional_dependencies: [
+      mccabe,
+      pycodestyle,
+      pyflakes,
+      pep8-naming,
+      flake8-bugbear,
+      flake8-comprehensions,
+    ]
 - repo: https://github.com/pycqa/pydocstyle
   rev: 5.0.2
   hooks:
   - id: pydocstyle
     args:
     - --count
+- repo: https://github.com/terrencepreilly/darglint
+  rev: master
+  hooks:
+  - id: darglint
+    args:
+    - --verbosity 2

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,0 +1,6 @@
+[pydocstyle]
+convention = google
+match = .*\.py
+# ignore =
+#   A,
+#   B,

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,4 +1,4 @@
-# <img alt="BackPACK" src="./logo/backpack_logo_no_torch.svg" height="90"> BackPACK developer manual
+# <img alt="BackPACK" src="./logo/backpack_logo_torch.svg" height="90"> BackPACK developer manual[¹]
 
 ## General standards 
 - Python version: support 3.5+, use 3.7 for development
@@ -60,3 +60,5 @@ make install-dev
     - Check docstring description matches definition: [`darglint`](https://github.com/terrencepreilly/darglint) ([`darglint` config](.darglint))
 - Optional [`pre-commit`](https://github.com/pre-commit/pre-commit) hooks [ `pre-commit` config ](.pre-commit-config.yaml)
 
+###### ¹ *BackPACK is not endorsed by or affiliated with Facebook, Inc. PyTorch, the PyTorch logo and any related marks are trademarks of Facebook, Inc.*
+[¹]:#-attribution-statement

--- a/README-dev.md
+++ b/README-dev.md
@@ -2,6 +2,7 @@
 
 ## General standards 
 - Python version: support 3.5+, use 3.7 for development
+- `git` [branching model](https://nvie.com/posts/a-successful-git-branching-model/)
 - Docstring style:  [Google](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
 - Test runner: [`pytest`](https://docs.pytest.org/en/latest/)
 - Formatting: [`black`](https://black.readthedocs.io) ([`black` config](black.toml))

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,4 +1,4 @@
-# <img alt="BackPACK" src="./logo/backpack_logo_torch.svg" height="90"> BackPACK developer manual[¹]
+# <img alt="BackPACK" src="./logo/backpack_logo_torch.svg" height="90"> BackPACK developer manual
 
 ## General standards 
 - Python version: support 3.5+, use 3.7 for development
@@ -60,5 +60,4 @@ make install-dev
     - Check docstring description matches definition: [`darglint`](https://github.com/terrencepreilly/darglint) ([`darglint` config](.darglint))
 - Optional [`pre-commit`](https://github.com/pre-commit/pre-commit) hooks [ `pre-commit` config ](.pre-commit-config.yaml)
 
-###### ¹ *BackPACK is not endorsed by or affiliated with Facebook, Inc. PyTorch, the PyTorch logo and any related marks are trademarks of Facebook, Inc.*
-[¹]:#-attribution-statement
+###### _BackPACK is not endorsed by or affiliated with Facebook, Inc. PyTorch, the PyTorch logo and any related marks are trademarks of Facebook, Inc._

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,10 +1,61 @@
-Basics about the development setup 
+# <img alt="BackPACK" src="./logo/backpack_logo_no_torch.svg" height="90"> BackPACK developer manual
 
-|-|-|
-|-|-|
-| Python version | The subset of Python 3 and Pytorch (`3.5, 3.6, 3.7`) and use `3.7` for development |
-| Tooling management | [`make`](https://www.gnu.org/software/make/) as an interface to the dev tools ([makefile](makefile)) |
-| Testing | [`pytest`](https://docs.pytest.org) ([testing readme](test/readme.md))
-| Style | [`black`](https://black.readthedocs.io) ([rules](black.toml)) for formatting and [`flake8`](http://flake8.pycqa.org/) ([rules](.flake8)) for linting |
-| CI/QA | [`Travis`](https://travis-ci.org/f-dangel/backpack) ([config](.travis.yaml)) to run tests and [`Github workflows`](https://github.com/f-dangel/backpack/actions) ([config](.github/workflows)) to check formatting and linting |
+## General standards 
+- Python version: support 3.5+, use 3.7 for development
+- Docstring style:  [Google](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
+- Test runner: [`pytest`](https://docs.pytest.org/en/latest/)
+- Formatting: [`black`](https://black.readthedocs.io) ([`black` config](black.toml))
+- Linting: [`flake8`](http://flake8.pycqa.org/) ([`flake8` config](.flake8))
+
+---
+
+The development tools are managed using [`make`](https://www.gnu.org/software/make/) as an interface ([`makefile`](makefile)). For an overview, call
+```bash
+make help 
+```
+  
+## Suggested workflow with [Anaconda](https://docs.anaconda.com/anaconda/install/)
+1. Clone the repository. Check out the `development` branch
+```bash
+git clone https://github.com/f-dangel/backpack.git ~/backpack
+cd ~/backpack
+git checkout development
+```
+2. Create `conda` environment `backpack` with the [environment file](.conda_env.yml). It comes with all dependencies installed, and BackPACK installed with the [--editable](http://codumentary.blogspot.com/2014/11/python-tip-of-year-pip-install-editable.html) option. Activate it.
+```bash
+make conda-env
+conda activate backpack
+```
+3. Install the development dependencies and `pre-commit` hooks
+```bash
+make install-dev
+```
+4. **You're set up!** Here are some useful commands for developing
+  - Run the tests
+    ```bash
+    make test
+    ```
+  - Lint code
+    ```bash
+    make flake8
+    ```
+  - Check format (code, imports, and docstrings)
+    ```bash
+    make format-check
+    ```
+
+## Details
+
+- Running quick/extensive tests: ([testing readme](test/readme.md))
+- Continuous Integration (CI)/Quality Assurance (QA)
+  - [`Travis`](https://travis-ci.org/f-dangel/backpack) ([`Travis` config](.travis.yaml))
+    - Run tests: [`pytest`](https://docs.pytest.org/en/latest/)
+    - Report test coverage: [`coveralls`](https://coveralls.io)
+    - Run examples
+  - [`Github workflows`](https://github.com/f-dangel/backpack/actions) ([config](.github/workflows))
+    - Check code formatting: [`black`](https://black.readthedocs.io) ([`black` config](black.toml))
+    - Lint code: [`flake8`](http://flake8.pycqa.org/) ([`flake8` config](.flake8))
+    - Check docstring style: [`pydocstyle`](https://github.com/PyCQA/pydocstyle) ([`pydocstyle` config](.pydocstyle))
+    - Check docstring description matches definition: [`darglint`](https://github.com/terrencepreilly/darglint) ([`darglint` config](.darglint))
+- Optional [`pre-commit`](https://github.com/pre-commit/pre-commit) hooks [ `pre-commit` config ](.pre-commit-config.yaml)
 

--- a/backpack/utils/ein.py
+++ b/backpack/utils/ein.py
@@ -38,65 +38,58 @@ def einsum(equation, *operands):
 
 
 def eingroup(equation, operand, dim=None):
-    """Use einsum notation for (un-)grouping dimensions.
+    """Use einsum-like notation for (un-)grouping dimensions.
 
-    Dimensions that cannot be inferred can be handed in via the
-    dictionary `dim`.
+    Dimensions that cannot be inferred can be handed in via a mapping `dim`.
 
-    Many operations in `backpack` require that certain axes of a tensor
-    be treated identically, and will therefore be grouped into a single
-    dimesion of the tensor. One way to do that is using `view`s or
-    `reshape`s. `eingroup` helps facilitate this process. It can be
-    used in the same way as `einsum`, but acts only on a single tensor at
-    a time (although this could be fixed with an improved syntax and
-    equation analysis).
+    Parameters:
+        equation (str): Equation specifying the (un-)grouping of axes.
+        operand (torch.Tensor): The tensor that `equation` will be applied to.
+        dim (dict, optional): A mapping from letters in `equation` to
+            dimensions. Only required if `eingroup` cannot infer the dimension.
+            For instance, consider you want to interpret a vector with 10
+            elements as a 5x2 matrix. The equation `"i,j->ij"` is not
+            sufficient, you need to specify `dim = {"i": 5, "j": 2}`.
 
-    Idea:
-    -----
-    * "a,b,c->ab,c": group dimension a and b into a single one
-    * "a,b,c->ba,c" to transpose, then group b and a dimension
+    Note:
+        Many operations in `backpack` require that certain axes of a tensor
+        be treated identically, and will therefore be grouped into a single
+        dimension. One way to do that is using `view`s or `reshape`s.
+        `eingroup` helps facilitate this process. It can be used in roughly
+        the same way as `einsum`, but acts only on a single tensor at
+        a time (although this could be fixed with an improved syntax and
+        equation analysis).
+
+        Idea:
+        * `"a,b,c->ab,c"`: group dimension `a` and `b` into a single one.
+        * `"a,b,c->ba,c"` to transpose, then group `b` and `a` dimension.
+
+    Examples:
+        Different reshapes of a [2 x 2 x 2] tensor:
+        >>> t = torch.Tensor([0, 1, 2, 3, 4, 5, 6, 7]).reshape(2, 2, 2)
+        >>> t_flat = t.reshape(-1)
+        >>> # group all dimensions
+        >>> eingroup("i,j,k->ijk", t)
+        torch.Tensor([0, 1, 2, 3, 4, 5, 6, 7])
+        >>> # interpret as 2 x 4 matrix
+        >>> eingroup("i,j,k->i,jk", t)
+        torch.Tensor([[0, 1, 2, 3], [4, 5, 6, 7]])
+        >>> # grouping (specifying grouping dimensions)
+        >>> eingroup("ijk->i,j,k", dim={"i": 2, "j": 2, "k": 2})
+        torch.Tensor([[[0, 1], [2, 3]], [[4, 5], [6, 7]]])
+        >>> # grouping with additional contraction
+        >>> eingroup("ijk->j,k", dim={"j": 2, "k": 2})
+        torch.Tensor([[[4, 5], [8, 10]])
+
+    Returns:
+        torch.Tensor: Result of the (un-)grouping operation.
 
     Raises:
-    -------
-    `KeyError`: If information about a dimension in `dim` is missing
-                or can be removed.
-    `RuntimeError`: If the groups inferred from `equation` do not match
-                    the number of axes of `operand`
+        KeyError: If information about a dimension in `dim` is missing
+            or can be removed. # noqa: DAR402
+        RuntimeError: If the groups inferred from `equation` do not match
+            the number of axes of `operand` # noqa: DAR402
 
-    Example usage:
-    ```
-    import torch
-    from backpack.utils.ein import einsum, eingroup
-
-    dim_a, dim_b, dim_c, dim_d = torch.randint(low=1, high=10, size=(4,))
-    tensor = torch.randn((dim_a, dim_b, dim_c, dim_d))
-
-    # 1) Transposition: Note the slightly different syntax for `eingroup`
-    tensor_trans = einsum("abcd->cbad", tensor)
-    tensor_trans_eingroup = eingroup("a,b,c,d->c,b,a,d", tensor)
-    assert torch.allclose(tensor_trans, tensor_trans_eingroup)
-
-    # 2) Grouping axes (a,c) and (b,d) together
-    tensor_group = einsum("abcd->acbd", tensor).reshape((dim_a * dim_c, dim_b * dim_d))
-    tensor_group_eingroup = eingroup("a,b,c,d->ac,bd", tensor)
-    assert torch.allclose(tensor_group, tensor_group_eingroup)
-
-    # 3) Ungrouping a tensor whose axes where merged
-    tensor_merge = tensor.reshape(dim_a * dim_b, dim_c, dim_d)
-    tensor_unmerge = tensor.reshape(dim_a, dim_b, dim_c, dim_d)
-    assert torch.allclose(tensor_unmerge, tensor)
-    # eingroup needs to know the dimensions of the ungrouped dimension
-    tensor_unmerge_eingroup = eingroup(
-        "ab,c,d->a,b,c,d", tensor_merge, dim={"a": dim_a, "b": dim_b}
-    )
-    assert torch.allclose(tensor_unmerge, tensor_unmerge_eingroup)
-
-    # 4) `einsum` functionality to sum out dimensions
-    # sum over dim_c, group dim_a and dim_d
-    tensor_sum = einsum("abcd->adb", tensor).reshape(dim_a * dim_d, dim_b)
-    tensor_sum_eingroup = eingroup("a,b,c,d->ad,b", tensor)
-    assert torch.allclose(tensor_sum, tensor_sum_eingroup)
-    ```
     """
 
     dim = {} if dim is None else dim

--- a/backpack/utils/ein.py
+++ b/backpack/utils/ein.py
@@ -1,5 +1,4 @@
-"""
-Einsum utility functions.
+"""Einsum utility functions.
 
 Makes it easy to switch to opt_einsum rather than torch's einsum for tests.
 """
@@ -42,7 +41,7 @@ def eingroup(equation, operand, dim=None):
 
     Dimensions that cannot be inferred can be handed in via a mapping `dim`.
 
-    Parameters:
+    Arguments:
         equation (str): Equation specifying the (un-)grouping of axes.
         operand (torch.Tensor): The tensor that `equation` will be applied to.
         dim (dict, optional): A mapping from letters in `equation` to
@@ -91,7 +90,6 @@ def eingroup(equation, operand, dim=None):
             the number of axes of `operand` # noqa: DAR402
 
     """
-
     dim = {} if dim is None else dim
     in_shape, out_shape, einsum_eq = _eingroup_preprocess(equation, operand, dim=dim)
 
@@ -121,7 +119,7 @@ def _eingroup_preprocess(equation, operand, dim):
 
 
 def __eingroup_shapes(in_groups, out_groups, dim):
-    """Return shape the input needs to be reshaped, and the output shape"""
+    """Return shape the input needs to be reshaped, and the output shape."""
 
     def shape(groups, dim):
         return [group_dim(group, dim) for group in groups]

--- a/makefile
+++ b/makefile
@@ -58,7 +58,7 @@ pydocstyle-check:
 	@pydocstyle --count .
 
 darglint-check:
-	@find . -name "*.py" | xargs darglint --verbosity 2
+	@darglint --verbosity 2 .
 
 isort:
 	@isort --apply

--- a/makefile
+++ b/makefile
@@ -6,6 +6,7 @@
 .PHONY: black isort format
 .PHONY: black-check isort-check format-check
 .PHONY: flake8
+.PHONY: pydocstyle-check
 
 .DEFAULT: help
 help:
@@ -17,6 +18,8 @@ help:
 	@echo "        Check if black would change files"
 	@echo "flake8"
 	@echo "        Run flake8 on the project"
+	@echo "pydocstyle-check"
+	@echo "        Run pydocstyle on the project"
 	@echo "install"
 	@echo "        Install backpack and dependencies"
 	@echo "install-dev"
@@ -48,6 +51,9 @@ black-check:
 flake8:
 	@flake8 .
 
+pydocstyle-check:
+	@pydocstyle --count .
+
 isort:
 	@isort --apply
 
@@ -59,7 +65,7 @@ format:
 	@make isort
 	@make black-check
 
-format-check: black-check isort-check
+format-check: black-check isort-check pydocstyle-check
 
 
 ###

--- a/makefile
+++ b/makefile
@@ -7,6 +7,7 @@
 .PHONY: black-check isort-check format-check
 .PHONY: flake8
 .PHONY: pydocstyle-check
+.PHONY: darglint-check
 
 .DEFAULT: help
 help:
@@ -20,6 +21,8 @@ help:
 	@echo "        Run flake8 on the project"
 	@echo "pydocstyle-check"
 	@echo "        Run pydocstyle on the project"
+	@echo "darglint-check"
+	@echo "        Run darglint on the project"
 	@echo "install"
 	@echo "        Install backpack and dependencies"
 	@echo "install-dev"
@@ -54,6 +57,9 @@ flake8:
 pydocstyle-check:
 	@pydocstyle --count .
 
+darglint-check:
+	@find . -name "*.py" | xargs darglint --verbosity 2
+
 isort:
 	@isort --apply
 
@@ -65,7 +71,7 @@ format:
 	@make isort
 	@make black-check
 
-format-check: black-check isort-check pydocstyle-check
+format-check: black-check isort-check pydocstyle-check darglint-check
 
 
 ###

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,3 +1,4 @@
+darglint
 flake8
 mccabe
 pycodestyle

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,6 +1,7 @@
 flake8
 mccabe
 pycodestyle
+pydocstyle
 pyflakes
 pep8-naming
 flake8-bugbear


### PR DESCRIPTION
This PR introduces `darglint` and `pydocstyle` as development tools to check existence/completeness/style of docstrings. More notes on development standards are listed in the [developer manual](https://github.com/f-dangel/backpack/blob/docstring-standards/README-dev.md).

Add GitHub actions and `pre-commit` hooks for the following `make` tasks:
```
# check docstrings with pydocstyle
make pydocstyle-check 
# check docstrings with darglint
make darglint-check
```