### PR TITLE
Sanity checks for second order backpropagation

### DIFF
--- a/backpack/core/derivatives/__init__.py
+++ b/backpack/core/derivatives/__init__.py
@@ -1,6 +1,7 @@
 from torch.nn import (
     AvgPool2d,
     Conv2d,
+    CrossEntropyLoss,
     Dropout,
     Linear,
     MaxPool2d,
@@ -12,6 +13,7 @@ from torch.nn import (
 
 from .avgpool2d import AvgPool2DDerivatives
 from .conv2d import Conv2DDerivatives
+from .crossentropyloss import CrossEntropyLossDerivatives
 from .dropout import DropoutDerivatives
 from .linear import LinearDerivatives
 from .maxpool2d import MaxPool2DDerivatives
@@ -30,4 +32,5 @@ derivatives_for = {
     ReLU: ReLUDerivatives,
     Tanh: TanhDerivatives,
     Sigmoid: SigmoidDerivatives,
+    CrossEntropyLoss: CrossEntropyLossDerivatives,
 }

--- a/backpack/core/derivatives/__init__.py
+++ b/backpack/core/derivatives/__init__.py
@@ -2,6 +2,7 @@ from torch.nn import (
     AvgPool2d,
     Conv2d,
     CrossEntropyLoss,
+    MSELoss,
     Dropout,
     Linear,
     MaxPool2d,
@@ -14,6 +15,7 @@ from torch.nn import (
 from .avgpool2d import AvgPool2DDerivatives
 from .conv2d import Conv2DDerivatives
 from .crossentropyloss import CrossEntropyLossDerivatives
+from .mseloss import MSELossDerivatives
 from .dropout import DropoutDerivatives
 from .linear import LinearDerivatives
 from .maxpool2d import MaxPool2DDerivatives
@@ -33,4 +35,5 @@ derivatives_for = {
     Tanh: TanhDerivatives,
     Sigmoid: SigmoidDerivatives,
     CrossEntropyLoss: CrossEntropyLossDerivatives,
+    MSELoss: MSELossDerivatives,
 }

--- a/backpack/core/derivatives/mseloss.py
+++ b/backpack/core/derivatives/mseloss.py
@@ -17,9 +17,9 @@ class MSELossDerivatives(BaseLossDerivatives):
         V_dim, C_dim = 0, 2
         diag = sqrt(2) * ones_like(module.input0)
         sqrt_H = diag_embed(diag, dim1=V_dim, dim2=C_dim)
+        N = module.input0_shape[0]
 
         if module.reduction == "mean":
-            N = module.input0.shape[0]
             sqrt_H /= sqrt(N)
 
         return sqrt_H
@@ -74,6 +74,10 @@ class MSELossDerivatives(BaseLossDerivatives):
     def check_input_dims(self, module):
         if not len(module.input0.shape) == 2:
             raise ValueError("Only 2D inputs are currently supported for MSELoss.")
+        if not module.input0.shape[1] == 1:
+            raise NotImplementedError(
+                "MSE between batches of vectors is not implemented yet."
+            )
 
     def hessian_is_psd(self):
         return True

--- a/test/test_second_order_warnings.py
+++ b/test/test_second_order_warnings.py
@@ -1,0 +1,94 @@
+"""Checks wether backpack correctly recognizes when 2nd order backprop would fail.
+
+Failure cases include
+- the loss if not the output of a torch.nn module
+- using unsupported parameters of the loss
+"""
+
+import pytest
+import torch
+from torch.nn import CrossEntropyLoss, MSELoss
+from backpack import extend
+from backpack import backpack as bp
+import backpack.extensions as bpext
+
+ext_2nd_order = [
+    bpext.KFAC,
+    bpext.KFRA,
+    bpext.KFLR,
+    bpext.DiagGGNExact,
+    bpext.DiagGGNMC,
+]
+ext_2nd_order_name = [
+    "KFAC",
+    "KFRA",
+    "KFLR",
+    "DiagGGNExact",
+    "DiagGGNExactMC",
+]
+
+
+def classification_targets(N, num_classes):
+    """Create random targets for classes 0, ..., `num_classes - 1`."""
+    return torch.randint(size=(N,), low=0, high=num_classes)
+
+
+def dummy_cross_entropy(N=5):
+    y_pred = torch.rand((N, 2))
+    y_pred.requires_grad = True
+    y = classification_targets(N, 2)
+    loss_module = extend(CrossEntropyLoss())
+    return loss_module(y_pred, y)
+
+
+def dummy_mse(N=5, D=1):
+    y_pred = torch.rand((N, D))
+    y_pred.requires_grad = True
+    y = torch.randn((N, D))
+    loss_module = extend(MSELoss())
+    return loss_module(y_pred, y)
+
+
+@pytest.mark.parametrize("extension", ext_2nd_order, ids=ext_2nd_order_name)
+def test_sqrt_hessian_crossentropy_should_pass(extension):
+    loss = dummy_cross_entropy()
+
+    with bp(extension()):
+        loss.backward()
+
+
+@pytest.mark.parametrize("extension", ext_2nd_order, ids=ext_2nd_order_name)
+def test_sqrt_hessian_mse_should_pass(extension):
+    loss = dummy_mse()
+
+    with bp(extension()):
+        loss.backward()
+
+
+@pytest.mark.parametrize("extension", ext_2nd_order, ids=ext_2nd_order_name)
+def test_sqrt_hessian_modified_crossentropy_should_fail(extension):
+    loss = dummy_cross_entropy() * 2
+
+    with pytest.warns(UserWarning):
+        with bp(extension()):
+            loss.backward()
+
+
+@pytest.mark.parametrize("extension", ext_2nd_order, ids=ext_2nd_order_name)
+def test_sqrt_hessian_modified_mse_should_fail(extension):
+    loss = dummy_mse() * 2
+
+    with pytest.warns(UserWarning):
+        with bp(extension()):
+            loss.backward()
+
+
+@pytest.mark.parametrize("extension", ext_2nd_order, ids=ext_2nd_order_name)
+def test_sqrt_hessian_mse_on_vectors_should_fail(extension):
+    loss = dummy_mse(D=2) * 2
+
+    with pytest.raises(
+        RuntimeError, match=r".*MSE between batches of vectors is not implemented yet.*"
+    ):
+        with bp(extension()):
+            loss.backward()

--- a/test/test_sqrt_hessian.py
+++ b/test/test_sqrt_hessian.py
@@ -1,0 +1,299 @@
+""" Test implementation of `sqrt_hessian` for loss derivatives. """
+
+import pytest
+import torch
+from torch.nn import CrossEntropyLoss
+
+from backpack import extend
+from backpack.core.derivatives import derivatives_for
+from backpack.hessianfree.hvp import hessian_vector_product
+from backpack import backpack as bp
+import backpack.extensions as bpext
+
+from .automated_test import check_sizes, check_values
+
+
+def classification_targets(N, num_classes):
+    """Create random targets for classes 0, ..., `num_classes - 1`."""
+    return torch.randint(size=(N,), low=0, high=num_classes)
+
+
+def make_id(layer, input_shape):
+    """Create an id for the test scenario."""
+    return "in{}-{}".format(input_shape, layer)
+
+
+torch.manual_seed(0)
+ARGS = "layer,input_shape,targets,raises"
+SETTINGS = [
+    # reduction mean
+    [
+        # layer
+        CrossEntropyLoss(reduction="mean"),
+        # input_shape
+        (2, 3),
+        # targets
+        classification_targets(N=2, num_classes=3),
+        # tuple of exceptions that should be raised
+        (),
+    ],
+    [
+        CrossEntropyLoss(reduction="mean"),
+        (8, 2),
+        classification_targets(N=8, num_classes=2),
+        (),
+    ],
+    # reduction sum
+    [
+        CrossEntropyLoss(reduction="sum"),
+        (2, 3),
+        classification_targets(N=2, num_classes=3),
+        (),
+    ],
+    [
+        CrossEntropyLoss(reduction="sum"),
+        (8, 2),
+        classification_targets(N=8, num_classes=2),
+        (),
+    ],
+    # non-scalar outputs are not supported
+    [
+        CrossEntropyLoss(reduction="none"),
+        (8, 2),
+        classification_targets(N=8, num_classes=2),
+        (ValueError,),
+    ],
+    # no reduction for a single number as input should be fine
+    [
+        CrossEntropyLoss(reduction="none"),
+        (1, 1),
+        classification_targets(N=1, num_classes=1),
+        (),
+    ],
+    # [MSELoss(reduction="mean"), (1, 5), None],
+    # [MSELoss(reduction="sum"), (2, 6), None],
+]
+IDS = [make_id(layer, input_shape) for (layer, input_shape, _, _) in SETTINGS]
+
+
+def autograd_hessian(loss, x):
+    """Return the Hessian matrix of `loss` w.r.t. `x`.
+
+    Arguments:
+        loss (torch.Tensor): A scalar-valued tensor.
+        x (torch.Tensor): Tensor used in the computation graph of `loss`.
+
+    Shapes:
+        loss: `[1,]`
+        x: `[A, B, C, ...]`
+
+    Returns:
+        torch.Tensor: Hessian tensor of `loss` w.r.t. `x`. The Hessian has shape
+            `[A, B, C, ..., A, B, C, ...]`.
+    """
+    assert loss.numel() == 1
+
+    vectorized_shape = (x.numel(), x.numel())
+    final_shape = (*x.shape, *x.shape)
+
+    hessian_vec_x = torch.zeros(vectorized_shape)
+
+    num_cols = hessian_vec_x.shape[1]
+    for column_idx in range(num_cols):
+        unit = torch.zeros(num_cols)
+        unit[column_idx] = 1.0
+
+        unit = unit.view_as(x)
+        column = hessian_vector_product(loss, [x], [unit])[0].reshape(-1)
+
+        hessian_vec_x[:, column_idx] = column
+
+    return hessian_vec_x.reshape(final_shape)
+
+
+def autograd_input_hessian(layer, input, targets):
+    """Compute the Hessian of a loss module w.r.t. its input."""
+    input.requires_grad = True
+
+    loss = layer(input, targets)
+    return autograd_hessian(loss, input)
+
+
+# TODO remove duplicate
+def derivative_from_layer(layer):
+    layer_to_derivative = derivatives_for
+
+    for module_cls, derivative_cls in layer_to_derivative.items():
+        if isinstance(layer, module_cls):
+            return derivative_cls()
+
+    raise RuntimeError("No derivative available for {}".format(layer))
+
+
+def embed(individual_hessians, input):
+    hessian_shape = (*input.shape, *input.shape)
+    hessian = torch.zeros(hessian_shape)
+
+    N = input.shape[0]
+
+    for n in range(N):
+        num_axes = len(input.shape)
+
+        if num_axes == 2:
+            hessian[n, :, n, :] = individual_hessians[n]
+        else:
+            raise ValueError("Only 2D inputs are currently supported.")
+
+    return hessian
+
+
+def backpack_hessian_via_sqrt_hessian(layer, input, targets):
+    layer = extend(layer)
+    derivative = derivative_from_layer(layer)
+
+    # forward pass to initialize backpack buffers
+    _ = layer(input, targets)
+
+    sqrt_hessian = derivative.sqrt_hessian(layer, None, None)
+    individual_hessians = sample_hessians_from_sqrt(sqrt_hessian)
+
+    hessian = embed(individual_hessians, input)
+
+    return hessian
+
+
+def backpack_hessian_via_sqrt_hessian_sampled(layer, input, targets):
+    MC_SAMPLES = 100000
+
+    layer = extend(layer)
+    derivative = derivative_from_layer(layer)
+
+    # forward pass to initialize backpack buffers
+    _ = layer(input, targets)
+
+    sqrt_hessian = derivative.sqrt_hessian_sampled(
+        layer, None, None, mc_samples=MC_SAMPLES
+    )
+    individual_hessians = sample_hessians_from_sqrt(sqrt_hessian)
+
+    # embed
+    # TODO improve readability
+    hessian_shape = (*input.shape, *input.shape)
+    hessian = torch.zeros(hessian_shape)
+
+    hessian = embed(individual_hessians, input)
+
+    return hessian
+
+
+def sample_hessians_from_sqrt(sqrt):
+    """Convert individual matrix square root into individual full matrix. """
+    equation = None
+    num_axes = len(sqrt.shape)
+
+    # TODO improve readability
+    if num_axes == 3:
+        equation = "vni,vnj->nij"
+    else:
+        raise ValueError("Only 2D inputs are currently supported.")
+
+    return torch.einsum(equation, sqrt, sqrt)
+
+
+def generate_data_input_hessian(input_shape):
+    return torch.rand(input_shape)
+
+
+@pytest.mark.parametrize(ARGS, SETTINGS, ids=IDS)
+def test_sqrt_hessian_via_input_hessian(layer, input_shape, targets, raises):
+    """Compare the Hessian to reconstruction from individual Hessian sqrt."""
+    torch.manual_seed(0)
+    input = generate_data_input_hessian(input_shape)
+    try:
+        return _compare_hessian_via_sqrt_hessian(layer, input, targets)
+    except Exception as e:
+        if isinstance(e, raises):
+            return
+        else:
+            raise e
+
+
+def _compare_hessian_via_sqrt_hessian(layer, input, targets):
+    backpack_result = backpack_hessian_via_sqrt_hessian(layer, input, targets)
+    autograd_result = autograd_input_hessian(layer, input, targets)
+
+    check_sizes(autograd_result, backpack_result)
+    check_values(autograd_result, backpack_result)
+
+    return backpack_result
+
+
+@pytest.mark.parametrize(ARGS, SETTINGS, ids=IDS)
+def test_sqrt_hessian_via_input_hessian_sampled(layer, input_shape, targets, raises):
+    """Compare the Hessian to reconstruction from individual sampled Hessian sqrt."""
+    torch.manual_seed(0)
+    input = generate_data_input_hessian(input_shape)
+    try:
+        return _compare_input_hessian_sampled(layer, input, targets)
+    except Exception as e:
+        if isinstance(e, raises):
+            return
+        else:
+            raise e
+
+
+def _compare_input_hessian_sampled(layer, input, targets):
+    RTOL = 1e-2
+    backpack_result = backpack_hessian_via_sqrt_hessian_sampled(layer, input, targets)
+    autograd_result = autograd_input_hessian(layer, input, targets)
+
+    check_sizes(autograd_result, backpack_result)
+    check_values(autograd_result, backpack_result, rtol=RTOL)
+
+    return backpack_result
+
+
+# %%
+# Test if backpack correctly recognizes when the loss if not the output of
+# a torch.nn module, and thus the second-order backpropagation would be wrong.
+
+ext_2nd_order = [
+    bpext.KFAC,
+    bpext.KFRA,
+    bpext.KFLR,
+    bpext.DiagGGNExact,
+    bpext.DiagGGNMC,
+]
+ext_2nd_order_name = [
+    "KFAC",
+    "KFRA",
+    "KFLR",
+    "DiagGGNExact",
+    "DiagGGNExactMC",
+]
+
+
+def sqrt_hessian_modified_dummy_loss_function():
+    N = 5
+    y_pred = torch.rand((N, 2))
+    y_pred.requires_grad = True
+    y = classification_targets(N, 2)
+    loss_module = extend(CrossEntropyLoss())
+    return loss_module(y_pred, y)
+
+
+@pytest.mark.parametrize("extension", ext_2nd_order, ids=ext_2nd_order_name)
+def test_sqrt_hessian_modified_loss_should_pass(extension):
+    loss = sqrt_hessian_modified_dummy_loss_function()
+
+    with bp(extension()):
+        loss.backward()
+
+
+@pytest.mark.parametrize("extension", ext_2nd_order, ids=ext_2nd_order_name)
+def test_sqrt_hessian_modified_loss_should_fail(extension):
+    loss = sqrt_hessian_modified_dummy_loss_function() * 2
+
+    with pytest.warns(UserWarning):
+        with bp(extension()):
+            loss.backward()

--- a/test/test_sqrt_hessian_sampled.py
+++ b/test/test_sqrt_hessian_sampled.py
@@ -1,0 +1,158 @@
+""" Test implementation of `sqrt_hessian_sampled` for loss derivatives. """
+
+
+import pytest
+import torch
+from torch.nn import CrossEntropyLoss, MSELoss
+
+from backpack import extend
+
+from .automated_test import check_sizes, check_values
+from .test_sqrt_hessian import (
+    autograd_input_hessian,
+    classification_targets,
+    derivative_from_layer,
+    embed,
+    generate_data_input_hessian,
+    make_id,
+    regression_targets,
+    sample_hessians_from_sqrt,
+)
+
+torch.manual_seed(0)
+ARGS = "layer,input_shape,targets,raises"
+SETTINGS = [
+    # reduction mean
+    [
+        # layer
+        CrossEntropyLoss(reduction="mean"),
+        # input_shape
+        (2, 3),
+        # targets
+        classification_targets(shape=(2,), num_classes=3),
+        # tuple of exceptions that should be raised
+        (),
+    ],
+    [
+        CrossEntropyLoss(reduction="mean"),
+        (8, 2),
+        classification_targets(shape=(8,), num_classes=2),
+        (),
+    ],
+    # reduction sum
+    [
+        CrossEntropyLoss(reduction="sum"),
+        (2, 3),
+        classification_targets(shape=(2,), num_classes=3),
+        (),
+    ],
+    [
+        CrossEntropyLoss(reduction="sum"),
+        (8, 2),
+        classification_targets(shape=(8,), num_classes=2),
+        (),
+    ],
+    # non-scalar outputs are not supported
+    [
+        CrossEntropyLoss(reduction="none"),
+        (8, 2),
+        classification_targets(shape=(8,), num_classes=2),
+        (ValueError,),
+    ],
+    # no reduction for a single number as input should be fine
+    [
+        CrossEntropyLoss(reduction="none"),
+        (1, 1),
+        classification_targets(shape=(1,), num_classes=1),
+        (),
+    ],
+    # reduction mean
+    [MSELoss(reduction="mean"), (5, 1), regression_targets(shape=(5, 1)), ()],
+    # reduction sum
+    [MSELoss(reduction="sum"), (5, 1), regression_targets(shape=(5, 1)), ()],
+    # no sampling implemented yet
+    [
+        MSELoss(reduction="sum"),
+        (5, 2),
+        regression_targets(shape=(5, 2)),
+        (NotImplementedError,),
+    ],
+    [
+        MSELoss(reduction="mean"),
+        (5, 2),
+        regression_targets(shape=(5, 2)),
+        (NotImplementedError,),
+    ],
+    # non-scalar outputs are not supported
+    [
+        MSELoss(reduction="none"),
+        (5, 1),
+        regression_targets(shape=(5, 1)),
+        (ValueError,),
+    ],
+]
+IDS = [make_id(layer, input_shape) for (layer, input_shape, _, _) in SETTINGS]
+
+
+def backpack_hessian_via_sqrt_hessian(layer, input, targets):
+    layer = extend(layer)
+    derivative = derivative_from_layer(layer)
+
+    # forward pass to initialize backpack buffers
+    _ = layer(input, targets)
+
+    sqrt_hessian = derivative.sqrt_hessian(layer, None, None)
+    individual_hessians = sample_hessians_from_sqrt(sqrt_hessian)
+
+    hessian = embed(individual_hessians, input)
+
+    return hessian
+
+
+def backpack_hessian_via_sqrt_hessian_sampled(layer, input, targets):
+    MC_SAMPLES = 100000
+
+    layer = extend(layer)
+    derivative = derivative_from_layer(layer)
+
+    # forward pass to initialize backpack buffers
+    _ = layer(input, targets)
+
+    sqrt_hessian = derivative.sqrt_hessian_sampled(
+        layer, None, None, mc_samples=MC_SAMPLES
+    )
+    individual_hessians = sample_hessians_from_sqrt(sqrt_hessian)
+
+    # embed
+    # TODO improve readability
+    hessian_shape = (*input.shape, *input.shape)
+    hessian = torch.zeros(hessian_shape)
+
+    hessian = embed(individual_hessians, input)
+
+    return hessian
+
+
+@pytest.mark.parametrize(ARGS, SETTINGS, ids=IDS)
+def test_sqrt_hessian_via_input_hessian_sampled(layer, input_shape, targets, raises):
+    """Compare the Hessian to reconstruction from individual sampled Hessian sqrt."""
+    torch.manual_seed(0)
+    input = generate_data_input_hessian(input_shape)
+    try:
+        return _compare_input_hessian_sampled(layer, input, targets)
+    except Exception as e:
+        if isinstance(e, raises):
+            return
+        else:
+            raise e
+
+
+def _compare_input_hessian_sampled(layer, input, targets):
+    RTOL = 1e-2
+    backpack_result = backpack_hessian_via_sqrt_hessian_sampled(layer, input, targets)
+    autograd_result = autograd_input_hessian(layer, input, targets)
+
+    check_sizes(autograd_result, backpack_result)
+    check_values(autograd_result, backpack_result, rtol=RTOL)
+
+    return backpack_result

--- a/test/test_sum_hessian.py
+++ b/test/test_sum_hessian.py
@@ -1,0 +1,165 @@
+"""Test implementation of `sum_hessian`"""
+
+
+import pytest
+import torch
+from torch.nn import CrossEntropyLoss, MSELoss
+
+from backpack import extend
+
+from .automated_test import check_sizes, check_values
+from .test_sqrt_hessian import (
+    autograd_hessian,
+    classification_targets,
+    derivative_from_layer,
+    generate_data_input_hessian,
+    make_id,
+    regression_targets,
+)
+
+torch.manual_seed(0)
+ARGS = "layer,input_shape,targets,raises"
+SETTINGS = [
+    # reduction mean
+    [
+        # layer
+        CrossEntropyLoss(reduction="mean"),
+        # input_shape
+        (2, 3),
+        # targets
+        classification_targets(shape=(2,), num_classes=3),
+        # tuple of exceptions that should be raised
+        (),
+    ],
+    [
+        CrossEntropyLoss(reduction="mean"),
+        (8, 2),
+        classification_targets(shape=(8,), num_classes=2),
+        (),
+    ],
+    # reduction sum
+    [
+        CrossEntropyLoss(reduction="sum"),
+        (2, 3),
+        classification_targets(shape=(2,), num_classes=3),
+        (),
+    ],
+    [
+        CrossEntropyLoss(reduction="sum"),
+        (8, 2),
+        classification_targets(shape=(8,), num_classes=2),
+        (),
+    ],
+    # non-scalar outputs are not supported
+    [
+        CrossEntropyLoss(reduction="none"),
+        (8, 2),
+        classification_targets(shape=(8,), num_classes=2),
+        (ValueError,),
+    ],
+    # no reduction for a single number as input should be fine
+    [
+        CrossEntropyLoss(reduction="none"),
+        (1, 1),
+        classification_targets(shape=(1,), num_classes=1),
+        (),
+    ],
+    # reduction mean
+    [MSELoss(reduction="mean"), (5, 1), regression_targets(shape=(5, 1)), ()],
+    [
+        MSELoss(reduction="mean"),
+        (5, 2),
+        regression_targets(shape=(5, 2)),
+        (NotImplementedError),
+    ],
+    # reduction sum
+    [MSELoss(reduction="sum"), (5, 1), regression_targets(shape=(5, 1)), ()],
+    [
+        MSELoss(reduction="sum"),
+        (5, 2),
+        regression_targets(shape=(5, 2)),
+        (NotImplementedError),
+    ],
+    # non-scalar outputs are not supported
+    [
+        MSELoss(reduction="none"),
+        (5, 1),
+        regression_targets(shape=(5, 1)),
+        (ValueError,),
+    ],
+]
+IDS = [make_id(layer, input_shape) for (layer, input_shape, _, _) in SETTINGS]
+
+
+def autograd_sum_hessian(layer, input, targets):
+    """Compute the Hessian of a loss module w.r.t. its input."""
+    input.requires_grad = True
+    loss = layer(input, targets)
+    hessian = autograd_hessian(loss, input)
+
+    sum_hessian = sum_hessian_blocks(hessian, input)
+
+    return sum_hessian
+
+
+def sum_hessian_blocks(hessian, input):
+    """Sum second derivatives over the batch dimension.
+    Assert second derivative w.r.t. different samples is zero.
+    """
+    num_axes = len(input.shape)
+
+    if num_axes != 2:
+        raise ValueError("Only 2D inputs are currently supported.")
+
+    N = input.shape[0]
+    num_features = input.numel() // N
+
+    sum_hessian = torch.zeros(num_features, num_features)
+
+    hessian_different_samples = torch.zeros(num_features, num_features)
+    for n_1 in range(N):
+        for n_2 in range(N):
+            block = hessian[n_1, :, n_2, :]
+
+            if n_1 == n_2:
+                sum_hessian += block
+
+            else:
+                assert torch.allclose(block, hessian_different_samples)
+
+    return sum_hessian
+
+
+def backpack_sum_hessian(layer, input, targets):
+    layer = extend(layer)
+    derivative = derivative_from_layer(layer)
+
+    # forward pass to initialize backpack buffers
+    _ = layer(input, targets)
+
+    sum_hessian = derivative.sum_hessian(layer, None, None)
+    return sum_hessian
+
+
+@pytest.mark.parametrize(ARGS, SETTINGS, ids=IDS)
+def test_sum_hessian(layer, input_shape, targets, raises):
+    """Compare the Hessian to reconstruction from individual Hessian sqrt."""
+    torch.manual_seed(0)
+    input = generate_data_input_hessian(input_shape)
+    try:
+        return _compare_sum_hessian(layer, input, targets)
+    except Exception as e:
+        if isinstance(e, raises):
+            return
+        else:
+            raise e
+
+
+def _compare_sum_hessian(layer, input, targets):
+    backpack_result = backpack_sum_hessian(layer, input, targets)
+    autograd_result = autograd_sum_hessian(layer, input, targets)
+
+    check_sizes(autograd_result, backpack_result)
+    check_values(autograd_result, backpack_result)
+
+    return backpack_result


### PR DESCRIPTION
Cleanup of #56 and #55;

- Raise warning if the loss has been modified beyond the last torch.nn loss module
- Raise warning if `backward`is called on non-scalar quantity
- Raise exception if CrossEntropy or MSE are used with not-yet-implemented parameters (MSE between vectors, CrossEntropy with `ignore_index` or `weight`
- Add test for expected behavior
