### PR TITLE
Deprecate python35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 python:
 - '3.6'
 - '3.7'
+- '3.8'
 install:
 - pip install -r requirements.txt
 - pip install -r requirements/test.txt
 - pip install .
-- pip install pillow==6.1.0
 cache:
 - pip
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '3.5'
 - '3.6'
 - '3.7'
 install:

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,7 +1,7 @@
 # <img alt="BackPACK" src="./logo/backpack_logo_torch.svg" height="90"> BackPACK developer manual
 
 ## General standards 
-- Python version: support 3.5+, use 3.7 for development
+- Python version: support 3.6+, use 3.7 for development
 - `git` [branching model](https://nvie.com/posts/a-successful-git-branching-model/)
 - Docstring style:  [Google](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
 - Test runner: [`pytest`](https://docs.pytest.org/en/latest/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis](https://travis-ci.org/f-dangel/backpack.svg?branch=master)](https://travis-ci.org/f-dangel/backpack)
 [![Coveralls](https://coveralls.io/repos/github/f-dangel/backpack/badge.svg?branch=master)](https://coveralls.io/github/f-dangel/backpack)
-[![Python 3.5+](https://img.shields.io/badge/python-3.5+-blue.svg)](https://www.python.org/downloads/release/python-350/)
+[![Python 3.6+](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/downloads/release/python-360/)
 
 BackPACK is built on top of [PyTorch](https://github.com/pytorch/pytorch). It efficiently computes quantities other than the gradient.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch >= 1.4.0, < 2.0.0
-torchvision >= 0.3.0, < 1.0.0
+torch >= 1.6.0, < 2.0.0
+torchvision >= 0.7.0, < 1.0.0

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
     license=LICENSE,
     packages=PACKAGES,
     zip_safe=False,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
* Use latest `torch` release (`1.6`)
* Remove `python3.5` from tests and add `python3.8`
* Update requirements and READMEs

Minor 
* Remove manual fix of `pillow` in travis

Background: PyTorch will drop support for python 3.5 with the [1.6 release](https://github.com/pytorch/pytorch/releases/tag/v1.6.0) (`CTRL f` "Dropped support for Python <= 3.5"). 