### PR TITLE
[core] Remove get_module

### DIFF
--- a/backpack/core/derivatives/avgpool2d.py
+++ b/backpack/core/derivatives/avgpool2d.py
@@ -2,16 +2,13 @@
 convolution over single channels with a constant kernel."""
 
 import torch.nn
-from torch.nn import AvgPool2d, Conv2d, ConvTranspose2d
+from torch.nn import Conv2d, ConvTranspose2d
 
 from backpack.core.derivatives.basederivatives import BaseDerivatives
 from backpack.utils.ein import eingroup
 
 
 class AvgPool2DDerivatives(BaseDerivatives):
-    def get_module(self):
-        return AvgPool2d
-
     def hessian_is_zero(self):
         return True
 

--- a/backpack/core/derivatives/batchnorm1d.py
+++ b/backpack/core/derivatives/batchnorm1d.py
@@ -1,15 +1,11 @@
 from warnings import warn
 
 from torch import einsum
-from torch.nn import BatchNorm1d
 
 from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
 
 
 class BatchNorm1dDerivatives(BaseParameterDerivatives):
-    def get_module(self):
-        return BatchNorm1d
-
     def hessian_is_zero(self):
         return False
 

--- a/backpack/core/derivatives/crossentropyloss.py
+++ b/backpack/core/derivatives/crossentropyloss.py
@@ -3,7 +3,6 @@ from math import sqrt
 
 from torch import diag, diag_embed, einsum, multinomial, ones_like, softmax
 from torch import sqrt as torchsqrt
-from torch.nn import CrossEntropyLoss
 from torch.nn.functional import one_hot
 
 from backpack.core.derivatives.basederivatives import BaseLossDerivatives
@@ -15,10 +14,6 @@ class CrossEntropyLossDerivatives(BaseLossDerivatives):
     The `torch.nn.CrossEntropyLoss` operation is a composition of softmax
     and negative log-likelihood.
     """
-
-    def get_module(self):
-        """Return the `torch.nn` module for cross-entropy loss."""
-        return CrossEntropyLoss
 
     def _sqrt_hessian(self, module, g_inp, g_out):
         self._check_2nd_order_parameters(module)

--- a/backpack/core/derivatives/dropout.py
+++ b/backpack/core/derivatives/dropout.py
@@ -1,13 +1,9 @@
 from torch import eq
-from torch.nn import Dropout
 
 from backpack.core.derivatives.elementwise import ElementwiseDerivatives
 
 
 class DropoutDerivatives(ElementwiseDerivatives):
-    def get_module(self):
-        return Dropout
-
     def hessian_is_zero(self):
         return True
 

--- a/backpack/core/derivatives/elu.py
+++ b/backpack/core/derivatives/elu.py
@@ -1,13 +1,9 @@
-from torch import gt, exp
-from torch.nn import ELU
+from torch import exp, gt
 
 from backpack.core.derivatives.elementwise import ElementwiseDerivatives
 
 
 class ELUDerivatives(ElementwiseDerivatives):
-    def get_module(self):
-        return ELU
-
     def hessian_is_zero(self):
         """`ELU''(x) ≠ 0`."""
         return False

--- a/backpack/core/derivatives/flatten.py
+++ b/backpack/core/derivatives/flatten.py
@@ -1,12 +1,7 @@
-from torch.nn import Flatten
-
 from backpack.core.derivatives.basederivatives import BaseDerivatives
 
 
 class FlattenDerivatives(BaseDerivatives):
-    def get_module(self):
-        return Flatten
-
     def hessian_is_zero(self):
         return True
 

--- a/backpack/core/derivatives/leakyrelu.py
+++ b/backpack/core/derivatives/leakyrelu.py
@@ -1,13 +1,9 @@
 from torch import gt
-from torch.nn import LeakyReLU
 
 from backpack.core.derivatives.elementwise import ElementwiseDerivatives
 
 
 class LeakyReLUDerivatives(ElementwiseDerivatives):
-    def get_module(self):
-        return LeakyReLU
-
     def hessian_is_zero(self):
         """`LeakyReLU''(x) = 0`."""
         return True

--- a/backpack/core/derivatives/linear.py
+++ b/backpack/core/derivatives/linear.py
@@ -1,5 +1,4 @@
 from torch import einsum
-from torch.nn import Linear
 
 from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
 
@@ -14,9 +13,6 @@ class LinearDerivatives(BaseParameterDerivatives):
     * o: Output dimension
     * i: Input dimension
     """
-
-    def get_module(self):
-        return Linear
 
     def hessian_is_zero(self):
         return True

--- a/backpack/core/derivatives/logsigmoid.py
+++ b/backpack/core/derivatives/logsigmoid.py
@@ -1,14 +1,9 @@
 from torch import exp
-from torch.nn import LogSigmoid
 
 from backpack.core.derivatives.elementwise import ElementwiseDerivatives
 
 
 class LogSigmoidDerivatives(ElementwiseDerivatives):
-    def get_module(self):
-        """Return `torch.nn.LogSigmoid` module class."""
-        return LogSigmoid
-
     def hessian_is_zero(self):
         """`logsigmoid''(x) ≠ 0`."""
         return False

--- a/backpack/core/derivatives/maxpool2d.py
+++ b/backpack/core/derivatives/maxpool2d.py
@@ -1,5 +1,4 @@
 from torch import zeros
-from torch.nn import MaxPool2d
 from torch.nn.functional import max_pool2d
 
 from backpack.core.derivatives.basederivatives import BaseDerivatives
@@ -7,8 +6,6 @@ from backpack.utils.ein import eingroup
 
 
 class MaxPool2DDerivatives(BaseDerivatives):
-    def get_module(self):
-        return MaxPool2d
 
     # TODO: Do not recompute but get from forward pass of module
     def get_pooling_idx(self, module):

--- a/backpack/core/derivatives/mseloss.py
+++ b/backpack/core/derivatives/mseloss.py
@@ -3,7 +3,6 @@
 from math import sqrt
 
 from torch import einsum, eye, normal
-from torch.nn import MSELoss
 
 from backpack.core.derivatives.basederivatives import BaseLossDerivatives
 
@@ -15,12 +14,7 @@ class MSELossDerivatives(BaseLossDerivatives):
 
     For `X : [n, d]` and `Y : [n, d]`, if `reduce=sum`, the MSE computes
     `∑ᵢ₌₁ⁿ ‖X[i,∶] − Y[i,∶]‖²`. If `reduce=mean`, the result is divided by `nd`.
-
-
     """
-
-    def get_module(self):
-        return MSELoss
 
     def _sqrt_hessian(self, module, g_inp, g_out):
         """Square-root of the hessian of the MSE for each minibatch elements.

--- a/backpack/core/derivatives/relu.py
+++ b/backpack/core/derivatives/relu.py
@@ -1,13 +1,9 @@
 from torch import gt
-from torch.nn import ReLU
 
 from backpack.core.derivatives.elementwise import ElementwiseDerivatives
 
 
 class ReLUDerivatives(ElementwiseDerivatives):
-    def get_module(self):
-        return ReLU
-
     def hessian_is_zero(self):
         """`ReLU''(x) = 0`."""
         return True

--- a/backpack/core/derivatives/selu.py
+++ b/backpack/core/derivatives/selu.py
@@ -1,5 +1,4 @@
-from torch import gt, exp
-from torch.nn import SELU
+from torch import exp, gt
 
 from backpack.core.derivatives.elementwise import ElementwiseDerivatives
 
@@ -9,9 +8,6 @@ class SELUDerivatives(ElementwiseDerivatives):
 
     alpha = 1.6732632423543772848170429916717
     scale = 1.0507009873554804934193349852946
-
-    def get_module(self):
-        return SELU
 
     def hessian_is_zero(self):
         """`SELU''(x) != 0`."""

--- a/backpack/core/derivatives/sigmoid.py
+++ b/backpack/core/derivatives/sigmoid.py
@@ -1,13 +1,7 @@
-from torch.nn import Sigmoid
-
 from backpack.core.derivatives.elementwise import ElementwiseDerivatives
 
 
 class SigmoidDerivatives(ElementwiseDerivatives):
-    def get_module(self):
-        """Return `torch.nn.Sigmoid` module class."""
-        return Sigmoid
-
     def hessian_is_zero(self):
         """`σ''(x) ≠ 0`."""
         return False

--- a/backpack/core/derivatives/tanh.py
+++ b/backpack/core/derivatives/tanh.py
@@ -1,12 +1,7 @@
-from torch.nn import Tanh
-
 from backpack.core.derivatives.elementwise import ElementwiseDerivatives
 
 
 class TanhDerivatives(ElementwiseDerivatives):
-    def get_module(self):
-        return Tanh
-
     def hessian_is_zero(self):
         return False
 

--- a/backpack/core/derivatives/zeropad2d.py
+++ b/backpack/core/derivatives/zeropad2d.py
@@ -1,13 +1,10 @@
-from torch.nn import ZeroPad2d, functional
+from torch.nn import functional
 
 from backpack.core.derivatives.basederivatives import BaseDerivatives
 from backpack.utils.ein import eingroup
 
 
 class ZeroPad2dDerivatives(BaseDerivatives):
-    def get_module(self):
-        return ZeroPad2d
-
     def hessian_is_zero(self):
         return True
 


### PR DESCRIPTION
One more clean-up in the core. The mapping of `nn.Module`s to derivatives is defined in `backpack/core/derivatives/__init__.py` and hence `get_modules` is redundant