### PR TITLE
[core] set default behavior of save_memory to True

### DIFF
--- a/backpack/core/derivatives/convnd.py
+++ b/backpack/core/derivatives/convnd.py
@@ -21,7 +21,7 @@ from backpack.utils.ein import eingroup
 class weight_jac_t_save_memory:
     """Choose algorithm to apply transposed convolution weight Jacobian."""
 
-    _SAVE_MEMORY = False
+    _SAVE_MEMORY = True
 
     def __init__(self, save_memory=True):
         self._new_save_memory = save_memory


### PR DESCRIPTION
This is a temporary change to compare `save_memory=False` with `save_memory=True` with our continuous benchmarking suite (https://f-dangel.github.io/backpack-benchmark/).

After updating the benchmarks and inspecting the results, it must be evaluated which choice should be kept as default.