### PR TITLE
Minor cleanup of Diagonal GGN extensions

### DIFF
--- a/backpack/extensions/__init__.py
+++ b/backpack/extensions/__init__.py
@@ -4,16 +4,7 @@ BackPACK Extensions
 
 from .curvmatprod import GGNMP, HMP, PCHMP
 from .firstorder import BatchGrad, BatchL2Grad, SumGradSquared, Variance
-from .secondorder import (
-    HBP,
-    KFAC,
-    KFLR,
-    KFRA,
-    DiagGGN,
-    DiagGGNExact,
-    DiagGGNMC,
-    DiagHessian,
-)
+from .secondorder import HBP, KFAC, KFLR, KFRA, DiagGGNExact, DiagGGNMC, DiagHessian
 
 __all__ = [
     "PCHMP",
@@ -29,6 +20,5 @@ __all__ = [
     "HBP",
     "DiagGGNExact",
     "DiagGGNMC",
-    "DiagGGN",
     "DiagHessian",
 ]

--- a/backpack/extensions/secondorder/__init__.py
+++ b/backpack/extensions/secondorder/__init__.py
@@ -18,14 +18,13 @@ The implemented extensions are
 - The diagonal of the Hessian :func:`DiagHessian <backpack.extensions.DiagHessian>`
 """
 
-from .diag_ggn import DiagGGN, DiagGGNExact, DiagGGNMC
+from .diag_ggn import DiagGGNExact, DiagGGNMC
 from .diag_hessian import DiagHessian
 from .hbp import HBP, KFAC, KFLR, KFRA
 
 __all__ = [
     "DiagGGNExact",
     "DiagGGNMC",
-    "DiagGGN",
     "DiagHessian",
     "KFAC",
     "KFLR",

--- a/backpack/extensions/secondorder/diag_ggn/__init__.py
+++ b/backpack/extensions/secondorder/diag_ggn/__init__.py
@@ -47,14 +47,14 @@ from . import (
 
 
 class DiagGGN(BackpropExtension):
+    """Base class for diagonal generalized Gauss-Newton/Fisher matrix."""
+
     VALID_LOSS_HESSIAN_STRATEGIES = [
         LossHessianStrategy.EXACT,
         LossHessianStrategy.SAMPLING,
     ]
 
-    def __init__(self, loss_hessian_strategy=LossHessianStrategy.EXACT, savefield=None):
-        if savefield is None:
-            savefield = "diag_ggn"
+    def __init__(self, loss_hessian_strategy, savefield):
         if loss_hessian_strategy not in self.VALID_LOSS_HESSIAN_STRATEGIES:
             raise ValueError(
                 "Unknown hessian strategy: {}".format(loss_hessian_strategy)
@@ -109,9 +109,7 @@ class DiagGGNExact(DiagGGN):
     """
 
     def __init__(self):
-        super().__init__(
-            loss_hessian_strategy=LossHessianStrategy.EXACT, savefield="diag_ggn_exact"
-        )
+        super().__init__(LossHessianStrategy.EXACT, "diag_ggn_exact")
 
 
 class DiagGGNMC(DiagGGN):
@@ -130,9 +128,7 @@ class DiagGGNMC(DiagGGN):
 
     def __init__(self, mc_samples=1):
         self._mc_samples = mc_samples
-        super().__init__(
-            loss_hessian_strategy=LossHessianStrategy.SAMPLING, savefield="diag_ggn_mc"
-        )
+        super().__init__(LossHessianStrategy.SAMPLING, "diag_ggn_mc")
 
     def get_num_mc_samples(self):
         return self._mc_samples

--- a/test/implementation/implementation_bpext.py
+++ b/test/implementation/implementation_bpext.py
@@ -42,9 +42,9 @@ class BpextImpl(Implementation):
         return sgs
 
     def diag_ggn(self):
-        with backpack(new_ext.DiagGGN()):
+        with backpack(new_ext.DiagGGNExact()):
             self.loss().backward()
-            diag_ggn = [p.diag_ggn for p in self.model.parameters()]
+            diag_ggn = [p.diag_ggn_exact for p in self.model.parameters()]
         return diag_ggn
 
     def diag_ggn_mc(self):

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -123,7 +123,7 @@ def test_interface_sum_grad_squared_conv():
 
 
 def test_interface_diag_ggn_conv():
-    interface_test(new_ext.DiagGGN(), use_conv=True)
+    interface_test(new_ext.DiagGGNExact(), use_conv=True)
 
 
 def test_interface_kflr_conv():

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -78,7 +78,7 @@ def test_interface_sum_grad_squared():
 
 
 def test_interface_diag_ggn():
-    interface_test(new_ext.DiagGGN())
+    interface_test(new_ext.DiagGGNExact())
 
 
 def test_interface_diag_h():


### PR DESCRIPTION
- Remove import of parent class `DiagGGN`
- Make parent class non-functioning by removing default `savefield` and `loss_hessian_strategy`