### PR TITLE
[core] Don't save memory in convolution weight_jac_t by default

### DIFF
--- a/backpack/core/derivatives/convnd.py
+++ b/backpack/core/derivatives/convnd.py
@@ -21,7 +21,7 @@ from einops import rearrange, reduce
 class weight_jac_t_save_memory:
     """Choose algorithm to apply transposed convolution weight Jacobian."""
 
-    _SAVE_MEMORY = True
+    _SAVE_MEMORY = False
 
     def __init__(self, save_memory=True):
         self._new_save_memory = save_memory


### PR DESCRIPTION
Resets the `save_memory` switch to the original value `False`. I will explain the switch in a future use case example together with our 'recommendations' how and when to use it, and a link to the benchmark.