### PR TITLE
[TEST] Use GitHub installation source for pytorch_memlab

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,4 @@ pytest-benchmark >= 3.2.2, < 4.0.0
 pytest-optional-tests >= 0.1.1
 pytest-cov
 coveralls
--e git://github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab
+git+git://github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,4 @@ pytest-benchmark >= 3.2.2, < 4.0.0
 pytest-optional-tests >= 0.1.1
 pytest-cov
 coveralls
-git://github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab
+-e git://github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,4 @@ pytest-benchmark >= 3.2.2, < 4.0.0
 pytest-optional-tests >= 0.1.1
 pytest-cov
 coveralls
-pytorch-memlab
+git://github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab


### PR DESCRIPTION
The PyPI release of `pytorch_memlab` does not catch a `RuntimeError` in `torch.cuda.reset_peak_memory_stats`. This causes the tests to break with the release of `torch==1.8.0`. The problem seems to have been fixed in [this commit](https://github.com/Stonesjtu/pytorch_memlab/commit/004895fb5e602daed6a83e1a7e1bcffa3c950997).

This PR modifies the installation source of `pytorch_memlab` to use a commit with the above fix.