### PR TITLE
in preparation of support for RNN, reduce output of each module if tuple

### DIFF
--- a/backpack/__init__.py
+++ b/backpack/__init__.py
@@ -133,11 +133,13 @@ class disable:
 
 def hook_store_io(module, input, output):
     """Saves the input and output as attributes of the module.
-
     Args:
-        module: module
+        module: the module on which to save the params
         input: List of input tensors
-        output: output tensor
+        output: output tensor, result of module(input)
+    Result:
+        list of inputs with index i is saved as module.input[i]
+        output is reduced to single output and saved as module.output
     """
     if disable.should_store_io() and torch.is_grad_enabled():
         for i in range(len(input)):

--- a/backpack/__init__.py
+++ b/backpack/__init__.py
@@ -133,13 +133,14 @@ class disable:
 
 def hook_store_io(module, input, output):
     """Saves the input and output as attributes of the module.
+
+    The list of inputs with index i is saved as module.input[i]
+    The output is reduced to single output tensor and saved as module.output
+
     Args:
-        module: the module on which to save the params
-        input: List of input tensors
-        output: output tensor, result of module(input)
-    Result:
-        list of inputs with index i is saved as module.input[i]
-        output is reduced to single output and saved as module.output
+        module (torch.nn.Module): the module on which to save the params
+        input (list): List of input tensors
+        output (torch.Tensor or tuple): result of module(input)
     """
     if disable.should_store_io() and torch.is_grad_enabled():
         for i in range(len(input)):

--- a/backpack/__init__.py
+++ b/backpack/__init__.py
@@ -142,7 +142,11 @@ def hook_store_io(module, input, output):
     if disable.should_store_io() and torch.is_grad_enabled():
         for i in range(len(input)):
             setattr(module, "input{}".format(i), input[i])
-        module.output = output
+        if isinstance(output, tuple):
+            # is true for RNN,GRU,LSTM which return tuple (output, ...)
+            module.output = output[0]
+        else:
+            module.output = output
 
 
 def memory_cleanup(module):

--- a/test/core/derivatives/problem.py
+++ b/test/core/derivatives/problem.py
@@ -132,6 +132,10 @@ class DerivativesTestProblem:
         else:
             output = module(input, target)
 
+        if isinstance(output, tuple):
+            # is true for RNN,GRU,LSTM which return tuple (output, ...)
+            output = output[0]
+
         return output.shape
 
     def is_loss(self):
@@ -152,6 +156,10 @@ class DerivativesTestProblem:
             output = self.module(input, self.target)
         else:
             output = self.module(input)
+
+        if isinstance(output, tuple):
+            # is true for RNN,GRU,LSTM which return tuple (output, ...)
+            output = output[0]
 
         return input, output, dict(self.module.named_parameters())
 


### PR DESCRIPTION
The output of an RNN module is tuple (output, h_n) ([RNN](https://pytorch.org/docs/stable/generated/torch.nn.RNN.html))
Similarly the output of LSTM and GRU is (output, ...) ([LSTM](https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html), [GRU](https://pytorch.org/docs/stable/generated/torch.nn.GRU.html))
Therefore, this output has to be reduced in the backward hook to be compatible with backpack calls.