### PR TITLE
Automate parameter function creation of BatchGrad and Grad extractors

### DIFF
--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -11,8 +11,10 @@ class BatchGradBase(FirstOrderModuleExtension):
     If child class wants to overwrite these methods
     - for example to support an additional external module -
     it can do so using the interface for parameter "param1"
+
     param1(ext, module, g_inp, g_out, bpQuantities):
         return batch_grads
+
     In this case, the method is not overwritten by this class.
     """
 
@@ -30,7 +32,7 @@ class BatchGradBase(FirstOrderModuleExtension):
         self.derivatives = derivatives
         for param_str in params:
             if not hasattr(self, param_str):
-                self.__setattr__(param_str, self._make_param_function(param_str))
+                setattr(self, param_str, self._make_param_function(param_str))
         super().__init__(params=params)
 
     def _make_param_function(self, param):
@@ -54,7 +56,7 @@ class BatchGradBase(FirstOrderModuleExtension):
                 bpQuantities(None): additional quantities for second order
 
             Returns:
-                torch.Tensor: individual gradients
+                torch.Tensor: scaled individual gradients
             """
             return getattr(self.derivatives, f"{param}_jac_t_mat_prod")(
                 module, g_inp, g_out, g_out[0], sum_batch=False

--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -1,17 +1,33 @@
+"""Passes the calls for the parameters to the derivatives class."""
 from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 
 
 class BatchGradBase(FirstOrderModuleExtension):
+    """Passes the calls for the parameters to the derivatives class.
+
+    This class implements functions with method name from params.
+    If child class wants to overwrite these methods,
+    this class needs to check if the method is already implemented.
+    """
+
     def __init__(self, derivatives, params=None):
+        """Initializes all methods.
+
+        Args:
+            derivatives
+                (backpack.core.derivatives.basederivatives.BaseParameterDerivatives):
+                Derivatives object assigned to self.derivatives.
+            params (list[str]): list of strings with parameter names. Defaults to None.
+        """
         self.derivatives = derivatives
+        for param_str in params:
+            self.__setattr__(param_str, self._make_function(param_str))
         super().__init__(params=params)
 
-    def bias(self, ext, module, g_inp, g_out, bpQuantities):
-        return self.derivatives.bias_jac_t_mat_prod(
-            module, g_inp, g_out, g_out[0], sum_batch=False
-        )
+    def _make_function(self, param):
+        def function(ext, module, g_inp, g_out, bpQuantities):
+            return getattr(self.derivatives, f"{param}_jac_t_mat_prod")(
+                module, g_inp, g_out, g_out[0], sum_batch=False
+            )
 
-    def weight(self, ext, module, g_inp, g_out, bpQuantities):
-        return self.derivatives.weight_jac_t_mat_prod(
-            module, g_inp, g_out, g_out[0], sum_batch=False
-        )
+        return function

--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -24,7 +24,7 @@ class BatchGradBase(FirstOrderModuleExtension):
         If the param method has already been defined, it is left unchanged.
 
         Args:
-            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):# noqa
+            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives): # noqa: B950
                 Derivatives object assigned to self.derivatives.
             params (list[str]): list of strings with parameter names.
                 For each, a method is assigned.

--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -1,11 +1,12 @@
-"""Passes the calls for the parameters to the derivatives class."""
+"""Calculates the batch_grad derivative."""
 from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 
 
 class BatchGradBase(FirstOrderModuleExtension):
-    """Passes the calls for the parameters to the derivatives class.
+    """Calculates the batch_grad derivative.
 
-    This class implements functions with method names from params.
+    Passes the calls for the parameters to the derivatives class.
+    Implements functions with method names from params.
 
     If child class wants to overwrite these methods
     - for example to support an additional external module -
@@ -15,7 +16,7 @@ class BatchGradBase(FirstOrderModuleExtension):
     In this case, the method is not overwritten by this class.
     """
 
-    def __init__(self, derivatives, params=None):
+    def __init__(self, derivatives, params):
         """Initializes all methods.
 
         If the param method has already been defined, it is left unchanged.
@@ -23,18 +24,40 @@ class BatchGradBase(FirstOrderModuleExtension):
         Args:
             derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):# noqa
                 Derivatives object assigned to self.derivatives.
-            params (list[str]): list of strings with parameter names. Defaults to None.
+            params (list[str]): list of strings with parameter names.
+                For each, a method is assigned.
         """
         self.derivatives = derivatives
         for param_str in params:
             if not hasattr(self, param_str):
-                self.__setattr__(param_str, self._make_function(param_str))
+                self.__setattr__(param_str, self._make_param_function(param_str))
         super().__init__(params=params)
 
-    def _make_function(self, param):
-        def function(ext, module, g_inp, g_out, bpQuantities):
+    def _make_param_function(self, param):
+        """Creates a function that calculates batch_grad wrt param.
+
+        Args:
+            param(str): name of parameter
+
+        Returns:
+            function: function that calculates batch_grad wrt param
+        """
+
+        def param_function(ext, module, g_inp, g_out, bpQuantities):
+            """Calculates batch_grad with the help of derivatives object.
+
+            Args:
+                ext(backpack.extensions.BatchGrad): extension that is used
+                module(torch.nn.Module): module that performed forward pass
+                g_inp(tuple[torch.Tensor]): input gradient tensors
+                g_out(tuple[torch.Tensor]): output gradient tensors
+                bpQuantities(None): additional quantities for second order
+
+            Returns:
+                torch.Tensor: individual gradients
+            """
             return getattr(self.derivatives, f"{param}_jac_t_mat_prod")(
                 module, g_inp, g_out, g_out[0], sum_batch=False
             )
 
-        return function
+        return param_function

--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -10,10 +10,10 @@ class BatchGradBase(FirstOrderModuleExtension):
 
     If child class wants to overwrite these methods
     - for example to support an additional external module -
-    it can do so using the interface for parameter "param1"
+    it can do so using the interface for parameter "param1"::
 
-    param1(ext, module, g_inp, g_out, bpQuantities):
-        return batch_grads
+        param1(ext, module, g_inp, g_out, bpQuantities):
+            return batch_grads
 
     In this case, the method is not overwritten by this class.
     """

--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -21,7 +21,7 @@ class BatchGradBase(FirstOrderModuleExtension):
         If the param method has already been defined, it is left unchanged.
 
         Args:
-            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):
+            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):# noqa
                 Derivatives object assigned to self.derivatives.
             params (list[str]): list of strings with parameter names. Defaults to None.
         """

--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -5,23 +5,30 @@ from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 class BatchGradBase(FirstOrderModuleExtension):
     """Passes the calls for the parameters to the derivatives class.
 
-    This class implements functions with method name from params.
-    If child class wants to overwrite these methods,
-    this class needs to check if the method is already implemented.
+    This class implements functions with method names from params.
+
+    If child class wants to overwrite these methods
+    - for example to support an additional external module -
+    it can do so using the interface for parameter "param1"
+    param1(ext, module, g_inp, g_out, bpQuantities):
+        return batch_grads
+    In this case, the method is not overwritten by this class.
     """
 
     def __init__(self, derivatives, params=None):
         """Initializes all methods.
 
+        If the param method has already been defined, it is left unchanged.
+
         Args:
-            derivatives
-                (backpack.core.derivatives.basederivatives.BaseParameterDerivatives):
+            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):
                 Derivatives object assigned to self.derivatives.
             params (list[str]): list of strings with parameter names. Defaults to None.
         """
         self.derivatives = derivatives
         for param_str in params:
-            self.__setattr__(param_str, self._make_function(param_str))
+            if not hasattr(self, param_str):
+                self.__setattr__(param_str, self._make_function(param_str))
         super().__init__(params=params)
 
     def _make_function(self, param):

--- a/backpack/extensions/firstorder/gradient/base.py
+++ b/backpack/extensions/firstorder/gradient/base.py
@@ -21,7 +21,7 @@ class GradBaseModule(FirstOrderModuleExtension):
         If the param method has already been defined, it is left unchanged.
 
         Args:
-            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):
+            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):# noqa
                 Derivatives object assigned to self.derivatives.
             params (list[str]): list of strings with parameter names. Defaults to None.
         """

--- a/backpack/extensions/firstorder/gradient/base.py
+++ b/backpack/extensions/firstorder/gradient/base.py
@@ -3,7 +3,7 @@ from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 
 
 class GradBaseModule(FirstOrderModuleExtension):
-    """calculates the gradient.
+    """Calculates the gradient.
 
     This class implements functions with method names from params.
 
@@ -13,8 +13,10 @@ class GradBaseModule(FirstOrderModuleExtension):
     If child class wants to overwrite these methods
     - for example to support an additional external module -
     it can do so using the interface for parameter "param1"
+
     param1(ext, module, g_inp, g_out, bpQuantities):
         return batch_grads
+
     In this case, the method is not overwritten by this class.
     """
 
@@ -32,7 +34,7 @@ class GradBaseModule(FirstOrderModuleExtension):
         self.derivatives = derivatives
         for param_str in params:
             if not hasattr(self, param_str):
-                self.__setattr__(param_str, self._make_param_function(param_str))
+                setattr(self, param_str, self._make_param_function(param_str))
         super().__init__(params=params)
 
     def _make_param_function(self, param):
@@ -56,7 +58,7 @@ class GradBaseModule(FirstOrderModuleExtension):
                 bpQuantities(None): additional quantities for second order
 
             Returns:
-                torch.Tensor: gradient of the batch
+                torch.Tensor: gradient of the batch, similar to autograd
             """
             return getattr(self.derivatives, f"{param}_jac_t_mat_prod")(
                 module, g_inp, g_out, g_out[0], sum_batch=True

--- a/backpack/extensions/firstorder/gradient/base.py
+++ b/backpack/extensions/firstorder/gradient/base.py
@@ -1,17 +1,33 @@
+"""Passes the calls for the parameters to the derivatives class."""
 from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 
 
-class GradBaseModule(FirstOrderModuleExtension):
+class BatchGradBase(FirstOrderModuleExtension):
+    """Passes the calls for the parameters to the derivatives class.
+
+    This class implements functions with method name from params.
+    If child class wants to overwrite these methods,
+    this class needs to check if the method is already implemented.
+    """
+
     def __init__(self, derivatives, params=None):
+        """Initializes all methods.
+
+        Args:
+            derivatives
+                (backpack.core.derivatives.basederivatives.BaseParameterDerivatives):
+                Derivatives object assigned to self.derivatives.
+            params (list[str]): list of strings with parameter names. Defaults to None.
+        """
         self.derivatives = derivatives
+        for param_str in params:
+            self.__setattr__(param_str, self._make_function(param_str))
         super().__init__(params=params)
 
-    def bias(self, ext, module, g_inp, g_out, bpQuantities):
-        return self.derivatives.bias_jac_t_mat_prod(
-            module, g_inp, g_out, g_out[0], sum_batch=True
-        )
+    def _make_function(self, param):
+        def function(ext, module, g_inp, g_out, bpQuantities):
+            return getattr(self.derivatives, f"{param}_jac_t_mat_prod")(
+                module, g_inp, g_out, g_out[0], sum_batch=True
+            )
 
-    def weight(self, ext, module, g_inp, g_out, bpQuantities):
-        return self.derivatives.weight_jac_t_mat_prod(
-            module, g_inp, g_out, g_out[0], sum_batch=True
-        )
+        return function

--- a/backpack/extensions/firstorder/gradient/base.py
+++ b/backpack/extensions/firstorder/gradient/base.py
@@ -24,7 +24,7 @@ class GradBaseModule(FirstOrderModuleExtension):
         If the param method has already been defined, it is left unchanged.
 
         Args:
-            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):# noqa
+            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives): # noqa: B950
                 Derivatives object assigned to self.derivatives.
             params (list[str]): list of strings with parameter names.
                 For each, a method is assigned.

--- a/backpack/extensions/firstorder/gradient/base.py
+++ b/backpack/extensions/firstorder/gradient/base.py
@@ -2,26 +2,33 @@
 from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 
 
-class BatchGradBase(FirstOrderModuleExtension):
+class GradBaseModule(FirstOrderModuleExtension):
     """Passes the calls for the parameters to the derivatives class.
 
-    This class implements functions with method name from params.
-    If child class wants to overwrite these methods,
-    this class needs to check if the method is already implemented.
+    This class implements functions with method names from params.
+
+    If child class wants to overwrite these methods
+    - for example to support an additional external module -
+    it can do so using the interface for parameter "param1"
+    param1(ext, module, g_inp, g_out, bpQuantities):
+        return batch_grads
+    In this case, the method is not overwritten by this class.
     """
 
     def __init__(self, derivatives, params=None):
         """Initializes all methods.
 
+        If the param method has already been defined, it is left unchanged.
+
         Args:
-            derivatives
-                (backpack.core.derivatives.basederivatives.BaseParameterDerivatives):
+            derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):
                 Derivatives object assigned to self.derivatives.
             params (list[str]): list of strings with parameter names. Defaults to None.
         """
         self.derivatives = derivatives
         for param_str in params:
-            self.__setattr__(param_str, self._make_function(param_str))
+            if not hasattr(self, param_str):
+                self.__setattr__(param_str, self._make_function(param_str))
         super().__init__(params=params)
 
     def _make_function(self, param):

--- a/backpack/extensions/firstorder/gradient/base.py
+++ b/backpack/extensions/firstorder/gradient/base.py
@@ -1,11 +1,14 @@
-"""Passes the calls for the parameters to the derivatives class."""
+"""Calculates the gradient."""
 from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 
 
 class GradBaseModule(FirstOrderModuleExtension):
-    """Passes the calls for the parameters to the derivatives class.
+    """calculates the gradient.
 
     This class implements functions with method names from params.
+
+    Passes the calls for the parameters to the derivatives class.
+    Implements functions with method names from params.
 
     If child class wants to overwrite these methods
     - for example to support an additional external module -
@@ -15,7 +18,7 @@ class GradBaseModule(FirstOrderModuleExtension):
     In this case, the method is not overwritten by this class.
     """
 
-    def __init__(self, derivatives, params=None):
+    def __init__(self, derivatives, params):
         """Initializes all methods.
 
         If the param method has already been defined, it is left unchanged.
@@ -23,18 +26,40 @@ class GradBaseModule(FirstOrderModuleExtension):
         Args:
             derivatives(backpack.core.derivatives.basederivatives.BaseParameterDerivatives):# noqa
                 Derivatives object assigned to self.derivatives.
-            params (list[str]): list of strings with parameter names. Defaults to None.
+            params (list[str]): list of strings with parameter names.
+                For each, a method is assigned.
         """
         self.derivatives = derivatives
         for param_str in params:
             if not hasattr(self, param_str):
-                self.__setattr__(param_str, self._make_function(param_str))
+                self.__setattr__(param_str, self._make_param_function(param_str))
         super().__init__(params=params)
 
-    def _make_function(self, param):
-        def function(ext, module, g_inp, g_out, bpQuantities):
+    def _make_param_function(self, param):
+        """Creates a function that calculates gradient wrt param.
+
+        Args:
+            param(str): name of parameter
+
+        Returns:
+            function: function that calculates gradient wrt param
+        """
+
+        def param_function(ext, module, g_inp, g_out, bpQuantities):
+            """Calculates gradient with the help of derivatives object.
+
+            Args:
+                ext(backpack.extensions.BatchGrad): extension that is used
+                module(torch.nn.Module): module that performed forward pass
+                g_inp(tuple[torch.Tensor]): input gradient tensors
+                g_out(tuple[torch.Tensor]): output gradient tensors
+                bpQuantities(None): additional quantities for second order
+
+            Returns:
+                torch.Tensor: gradient of the batch
+            """
             return getattr(self.derivatives, f"{param}_jac_t_mat_prod")(
                 module, g_inp, g_out, g_out[0], sum_batch=True
             )
 
-        return function
+        return param_function

--- a/backpack/extensions/firstorder/gradient/base.py
+++ b/backpack/extensions/firstorder/gradient/base.py
@@ -5,17 +5,15 @@ from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 class GradBaseModule(FirstOrderModuleExtension):
     """Calculates the gradient.
 
-    This class implements functions with method names from params.
-
     Passes the calls for the parameters to the derivatives class.
     Implements functions with method names from params.
 
     If child class wants to overwrite these methods
     - for example to support an additional external module -
-    it can do so using the interface for parameter "param1"
+    it can do so using the interface for parameter "param1"::
 
-    param1(ext, module, g_inp, g_out, bpQuantities):
-        return batch_grads
+        param1(ext, module, g_inp, g_out, bpQuantities):
+            return batch_grads
 
     In this case, the method is not overwritten by this class.
     """


### PR DESCRIPTION
To be more flexible with parameter names, refactor the firstorder extension such that arbitrary parameter names are supported.
Adding a support for a new module would then not require any additional changes to the firstorder modules for batch_grad.
Please review whether the docstrings are sufficient to understand the structure and purpose.
Please review whether the other firstorder modules should also be refactored.