### PR TITLE
Partial format tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -89,3 +89,33 @@ jobs:
     - name: Run darglint
       run: |
         make darglint-check
+  darglint-partial:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        make install-lint
+    - name: Run darglint
+      run: |
+        make darglint-check-partial
+  pydocstyle-partial:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install-lint
+      - name: Run pydocstyle
+        run: |
+          make pydocstyle-check-partial

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,11 @@ jobs:
     name: "Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     env:
-      USING_COVERAGE: '3.6,3.8'
+      USING_COVERAGE: '3.7,3.9'
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]      
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -1,0 +1,3 @@
+test/extensions/problem.py
+test/extensions/test_backprop_extension.py
+test/extensions/firstorder/firstorder_settings.py

--- a/makefile
+++ b/makefile
@@ -5,10 +5,10 @@
 .PHONY: test-light test-light-no-gpu
 .PHONY: conda-env
 .PHONY: black isort format
-.PHONY: black-check isort-check format-check
+.PHONY: black-check isort-check format-check format-check-partial
 .PHONY: flake8
-.PHONY: pydocstyle-check
-.PHONY: darglint-check
+.PHONY: pydocstyle-check pydocstyle-check-partial
+.PHONY: darglint-check darglint-check-partial
 .PHONY: build-docs
 
 .DEFAULT: help
@@ -29,8 +29,12 @@ help:
 	@echo "        Run flake8 on the project"
 	@echo "pydocstyle-check"
 	@echo "        Run pydocstyle on the project"
+	@echo "pydocstyle-check-partial"
+	@echo "        Run pydocstyle on documented part of the project"
 	@echo "darglint-check"
 	@echo "        Run darglint on the project"
+	@echo "darglint-check-partial"
+	@echo "        Run darglint on documented part of the project"
 	@echo "install"
 	@echo "        Install backpack and dependencies"
 	@echo "isort"
@@ -82,8 +86,14 @@ flake8:
 pydocstyle-check:
 	@pydocstyle --count .
 
+pydocstyle-check-partial:
+	@pydocstyle --count $(shell grep -v '^#' fully_documented.txt )
+
 darglint-check:
 	@darglint --verbosity 2 .
+
+darglint-check-partial:
+	@darglint --verbosity 2 $(shell grep -v '^#' fully_documented.txt)
 
 isort:
 	@isort .
@@ -96,8 +106,9 @@ format:
 	@make isort
 	@make black-check
 
-format-check: black-check isort-check pydocstyle-check darglint-check
+format-check: black-check isort-check flake8 pydocstyle-check darglint-check
 
+format-check-partial: black-check isort-check flake8 pydocstyle-check-partial darglint-check-partial
 
 ###
 # Installation


### PR DESCRIPTION
Introduce partial format tests. The files that must be fully documented are defined in fully_documented.txt. This file is going to be populated later.
The tests are now run on Python 3.7 - 3.9. This is because later pull requests will use type hints using [PEP 563](https://www.python.org/dev/peps/pep-0563/) that was introduced in Python 3.7. These later pull requests will lead to BackPACK requiring python version 3.7 or higher.