### PR TITLE
[CI] Introduce partial docstring checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -88,3 +88,33 @@ jobs:
     - name: Run darglint
       run: |
         make darglint-check
+  darglint-partial:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        make install-lint
+    - name: Run darglint
+      run: |
+        make darglint-check-partial
+  pydocstyle-partial:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install-lint
+      - name: Run pydocstyle
+        run: |
+          make pydocstyle-check-partial

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -1,0 +1,1 @@
+test/extensions/test_backprop_extension.py

--- a/makefile
+++ b/makefile
@@ -5,10 +5,10 @@
 .PHONY: test-light test-light-no-gpu
 .PHONY: conda-env
 .PHONY: black isort format
-.PHONY: black-check isort-check format-check
+.PHONY: black-check isort-check format-check format-check-partial
 .PHONY: flake8
-.PHONY: pydocstyle-check
-.PHONY: darglint-check
+.PHONY: pydocstyle-check pydocstyle-check-partial
+.PHONY: darglint-check darglint-check-partial
 .PHONY: build-docs
 
 .DEFAULT: help
@@ -29,8 +29,12 @@ help:
 	@echo "        Run flake8 on the project"
 	@echo "pydocstyle-check"
 	@echo "        Run pydocstyle on the project"
+	@echo "pydocstyle-check-partial"
+	@echo "        Run pydocstyle on documented part of the project"
 	@echo "darglint-check"
 	@echo "        Run darglint on the project"
+	@echo "darglint-check-partial"
+	@echo "        Run darglint on documented part of the project"
 	@echo "install"
 	@echo "        Install backpack and dependencies"
 	@echo "isort"
@@ -82,8 +86,14 @@ flake8:
 pydocstyle-check:
 	@pydocstyle --count .
 
+pydocstyle-check-partial:
+	@pydocstyle --count $(shell grep -v '^#' fully_documented.txt )
+
 darglint-check:
 	@darglint --verbosity 2 .
+
+darglint-check-partial:
+	@darglint --verbosity 2 $(shell grep -v '^#' fully_documented.txt)
 
 isort:
 	@isort .
@@ -96,8 +106,9 @@ format:
 	@make isort
 	@make black-check
 
-format-check: black-check isort-check pydocstyle-check darglint-check
+format-check: black-check isort-check flake8 pydocstyle-check darglint-check
 
+format-check-partial: black-check isort-check flake8 pydocstyle-check-partial darglint-check-partial
 
 ###
 # Installation


### PR DESCRIPTION
Fully documented files are added to `fully_documented.txt`. Once the
entire code base is documented, the partial checks can be removed, and
the full tests be turned on.

Taken from 91e85e5f6e49d4cd5e0c726e02fa62d3014a27d7.