### PR TITLE
RNN first order extensions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+# https://coverage.readthedocs.io/en/v4.5.x/config.html#config
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise NotImplementedError
+
+    # TYPE_CHECKING block is never executed during pytest run
+    if TYPE_CHECKING:

--- a/backpack/core/derivatives/rnn.py
+++ b/backpack/core/derivatives/rnn.py
@@ -31,20 +31,20 @@ class RNNDerivatives(BaseParameterDerivatives):
             module: module which to check
 
         Raises:
-            ValueError: If any parameter of module does not match expectation
+            NotImplementedError: If any parameter of module does not match expectation
         """
         if module.num_layers > 1:
-            raise ValueError("only num_layers = 1 is supported")
+            raise NotImplementedError("only num_layers = 1 is supported")
         if not module.nonlinearity == "tanh":
-            raise ValueError("only nonlinearity = tanh is supported")
+            raise NotImplementedError("only nonlinearity = tanh is supported")
         if module.bias is not True:
-            raise ValueError("only bias = True is supported")
+            raise NotImplementedError("only bias = True is supported")
         if module.batch_first is not False:
-            raise ValueError("only batch_first = False is supported")
+            raise NotImplementedError("only batch_first = False is supported")
         if not module.dropout == 0:
-            raise ValueError("only dropout = 0 is supported")
+            raise NotImplementedError("only dropout = 0 is supported")
         if module.bidirectional is not False:
-            raise ValueError("only bidirectional = False is supported")
+            raise NotImplementedError("only bidirectional = False is supported")
 
     @staticmethod
     def _a_jac_t_mat_prod(

--- a/backpack/custom_module/__init__.py
+++ b/backpack/custom_module/__init__.py
@@ -1,0 +1,4 @@
+"""This package adds torch.nn.Module type modules.
+
+These are used as utilities.
+"""

--- a/backpack/custom_module/permute.py
+++ b/backpack/custom_module/permute.py
@@ -1,0 +1,29 @@
+"""Module containing Permute module."""
+from typing import Any
+
+from torch import Tensor
+from torch.nn import Module
+
+
+class Permute(Module):
+    """Module to permute a tensor."""
+
+    def __init__(self, dims: Any):
+        """Initialization.
+
+        Args:
+            dims: The desired ordering of dimensions.
+        """
+        super(Permute, self).__init__()
+        self.dims = dims
+
+    def forward(self, input: Tensor) -> Tensor:
+        """Permutes the input tensor.
+
+        Args:
+            input: input tensor
+
+        Returns:
+            view with new ordering
+        """
+        return input.permute(self.dims)

--- a/backpack/custom_module/permute.py
+++ b/backpack/custom_module/permute.py
@@ -8,7 +8,7 @@ from torch.nn import Module
 class Permute(Module):
     """Module to permute a tensor."""
 
-    def __init__(self, dims: Any):
+    def __init__(self, *dims: Any):
         """Initialization.
 
         Args:

--- a/backpack/custom_module/reduce_tuple.py
+++ b/backpack/custom_module/reduce_tuple.py
@@ -1,0 +1,29 @@
+"""Module containing ReduceTuple module."""
+from typing import Union
+
+from torch import Tensor
+from torch.nn import Module
+
+
+class ReduceTuple(Module):
+    """Module reducing tuple input."""
+
+    def __init__(self, index: int = 0):
+        """Initialization.
+
+        Args:
+            index: which element to choose
+        """
+        super(ReduceTuple, self).__init__()
+        self.index = index
+
+    def forward(self, input: tuple) -> Union[tuple, Tensor]:
+        """Reduces the tuple.
+
+        Args:
+            input: the tuple of data
+
+        Returns:
+            the selected element
+        """
+        return input[self.index]

--- a/backpack/extensions/firstorder/batch_grad/__init__.py
+++ b/backpack/extensions/firstorder/batch_grad/__init__.py
@@ -1,4 +1,9 @@
+"""Contains the backpropagation extension for grad_batch: BatchGrad.
+
+It defines the module extension for each module.
+"""
 from torch.nn import (
+    RNN,
     BatchNorm1d,
     Conv1d,
     Conv2d,
@@ -20,6 +25,7 @@ from . import (
     conv_transpose2d,
     conv_transpose3d,
     linear,
+    rnn,
 )
 
 
@@ -39,10 +45,13 @@ class BatchGrad(BackpropExtension):
 
     The concept of individual gradients is only meaningful if the
     objective is a sum of independent functions (no batchnorm).
-
     """
 
     def __init__(self):
+        """Initialization.
+
+        Defines extension for each module.
+        """
         super().__init__(
             savefield="grad_batch",
             fail_mode="WARNING",
@@ -55,5 +64,6 @@ class BatchGrad(BackpropExtension):
                 ConvTranspose2d: conv_transpose2d.BatchGradConvTranspose2d(),
                 ConvTranspose3d: conv_transpose3d.BatchGradConvTranspose3d(),
                 BatchNorm1d: batchnorm1d.BatchGradBatchNorm1d(),
+                RNN: rnn.BatchGradRNN(),
             },
         )

--- a/backpack/extensions/firstorder/batch_grad/rnn.py
+++ b/backpack/extensions/firstorder/batch_grad/rnn.py
@@ -1,0 +1,14 @@
+"""Contains BatchGradRNN."""
+from backpack.core.derivatives.rnn import RNNDerivatives
+from backpack.extensions.firstorder.batch_grad.batch_grad_base import BatchGradBase
+
+
+class BatchGradRNN(BatchGradBase):
+    """Extension for RNN calculating grad_batch."""
+
+    def __init__(self):
+        """Initialization."""
+        super().__init__(
+            derivatives=RNNDerivatives(),
+            params=["bias_ih_l0", "bias_hh_l0", "weight_ih_l0", "weight_hh_l0"],
+        )

--- a/backpack/extensions/firstorder/batch_l2_grad/__init__.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/__init__.py
@@ -1,4 +1,10 @@
+"""Contains BatchL2Grad.
+
+Defines the backpropagation extension.
+Within it, define the extension for each module.
+"""
 from torch.nn import (
+    RNN,
     Conv1d,
     Conv2d,
     Conv3d,
@@ -18,6 +24,7 @@ from . import (
     convtranspose2d,
     convtranspose3d,
     linear,
+    rnn,
 )
 
 
@@ -37,7 +44,11 @@ class BatchL2Grad(BackpropExtension):
     """
 
     def __init__(self):
-        super().__init__(
+        """Initialization.
+
+        Define the extensions for each module.
+        """
+        super(BatchL2Grad, self).__init__(
             savefield="batch_l2",
             fail_mode="WARNING",
             module_exts={
@@ -48,5 +59,6 @@ class BatchL2Grad(BackpropExtension):
                 ConvTranspose1d: convtranspose1d.BatchL2ConvTranspose1d(),
                 ConvTranspose2d: convtranspose2d.BatchL2ConvTranspose2d(),
                 ConvTranspose3d: convtranspose3d.BatchL2ConvTranspose3d(),
+                RNN: rnn.BatchL2RNN(),
             },
         )

--- a/backpack/extensions/firstorder/batch_l2_grad/rnn.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/rnn.py
@@ -1,0 +1,72 @@
+"""Contains BatchL2RNN."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Tuple
+
+from torch import Tensor
+from torch.nn import Module
+
+from backpack.core.derivatives.rnn import RNNDerivatives
+from backpack.extensions.firstorder.base import FirstOrderModuleExtension
+
+if TYPE_CHECKING:
+    from backpack.extensions import BatchL2Grad
+
+
+class BatchL2RNN(FirstOrderModuleExtension):
+    """Extension for RNN, calculating batch_l2."""
+
+    def __init__(self):
+        """Initialization."""
+        params = ["bias_ih_l0", "bias_hh_l0", "weight_ih_l0", "weight_hh_l0"]
+        for param_str in params:
+            if not hasattr(self, param_str):
+                setattr(self, param_str, self._make_param_function(param_str))
+        super(BatchL2RNN, self).__init__(
+            params=params,
+        )
+        self.derivatives: RNNDerivatives = RNNDerivatives()
+
+    def _make_param_function(
+        self, param_str: str
+    ) -> Callable[[BatchL2Grad, Module, Tuple[Tensor], Tuple[Tensor], None], Tensor]:
+        """Creates a function that calculates batch_l2.
+
+        Args:
+            param_str: name of parameter
+
+        Returns:
+            function that calculates batch_l2
+        """
+
+        def param_function(
+            ext: BatchL2Grad,
+            module: Module,
+            g_inp: Tuple[Tensor],
+            g_out: Tuple[Tensor],
+            bpQuantities: None,
+        ) -> Tensor:
+            """Calculates batch_l2 with the help of derivatives object.
+
+            Args:
+                ext: extension that is used
+                module: module that performed forward pass
+                g_inp: input gradient tensors
+                g_out: output gradient tensors
+                bpQuantities: additional quantities for second order
+
+            Returns:
+                batch_l2
+            """
+            return (
+                (
+                    getattr(self.derivatives, f"{param_str}_jac_t_mat_prod")(
+                        module, g_inp, g_out, g_out[0], sum_batch=False
+                    )
+                    ** 2
+                )
+                .flatten(start_dim=1)
+                .sum(1)
+            )
+
+        return param_function

--- a/backpack/extensions/firstorder/batch_l2_grad/rnn.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/rnn.py
@@ -22,9 +22,7 @@ class BatchL2RNN(FirstOrderModuleExtension):
         for param_str in params:
             if not hasattr(self, param_str):
                 setattr(self, param_str, self._make_param_function(param_str))
-        super(BatchL2RNN, self).__init__(
-            params=params,
-        )
+        super(BatchL2RNN, self).__init__(params=params)
         self.derivatives: RNNDerivatives = RNNDerivatives()
 
     def _make_param_function(

--- a/backpack/extensions/firstorder/gradient/__init__.py
+++ b/backpack/extensions/firstorder/gradient/__init__.py
@@ -1,1 +1,5 @@
+"""This package contains the gradient extension.
+
+It calculates the same result as torch backward().
+"""
 # TODO: Rewrite variance to not need this extension

--- a/backpack/extensions/firstorder/gradient/rnn.py
+++ b/backpack/extensions/firstorder/gradient/rnn.py
@@ -1,0 +1,15 @@
+"""Contains GradRNN."""
+from backpack.core.derivatives.rnn import RNNDerivatives
+
+from .base import GradBaseModule
+
+
+class GradRNN(GradBaseModule):
+    """Extension for RNN, calculating gradient."""
+
+    def __init__(self):
+        """Initialization."""
+        super().__init__(
+            derivatives=RNNDerivatives(),
+            params=["bias_ih_l0", "bias_hh_l0", "weight_ih_l0", "weight_hh_l0"],
+        )

--- a/backpack/extensions/firstorder/sum_grad_squared/__init__.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/__init__.py
@@ -1,4 +1,9 @@
+"""Contains backpropagation extension for sum_grad_squared: SumGradSquared.
+
+Defines module extension for each module.
+"""
 from torch.nn import (
+    RNN,
     Conv1d,
     Conv2d,
     Conv3d,
@@ -18,6 +23,7 @@ from . import (
     convtranspose2d,
     convtranspose3d,
     linear,
+    rnn,
 )
 
 
@@ -36,6 +42,10 @@ class SumGradSquared(BackpropExtension):
     """
 
     def __init__(self):
+        """Initialization.
+
+        Defines module extension for each module.
+        """
         super().__init__(
             savefield="sum_grad_squared",
             fail_mode="WARNING",
@@ -47,5 +57,6 @@ class SumGradSquared(BackpropExtension):
                 ConvTranspose1d: convtranspose1d.SGSConvTranspose1d(),
                 ConvTranspose2d: convtranspose2d.SGSConvTranspose2d(),
                 ConvTranspose3d: convtranspose3d.SGSConvTranspose3d(),
+                RNN: rnn.SGSRNN(),
             },
         )

--- a/backpack/extensions/firstorder/sum_grad_squared/rnn.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/rnn.py
@@ -1,0 +1,14 @@
+"""Contains SGSRNN module."""
+from backpack.core.derivatives.rnn import RNNDerivatives
+from backpack.extensions.firstorder.sum_grad_squared.sgs_base import SGSBase
+
+
+class SGSRNN(SGSBase):
+    """Extension for RNN, calculating sum_gradient_squared."""
+
+    def __init__(self):
+        """Initialization."""
+        super(SGSRNN, self).__init__(
+            derivatives=RNNDerivatives(),
+            params=["bias_ih_l0", "bias_hh_l0", "weight_ih_l0", "weight_hh_l0"],
+        )

--- a/backpack/extensions/firstorder/sum_grad_squared/sgs_base.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/sgs_base.py
@@ -1,20 +1,71 @@
+"""Contains SGSBase, the base module for sum_grad_squared extension."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, List, Tuple
+
+from torch import Tensor
+from torch.nn import Module
+
+from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
 from backpack.extensions.firstorder.base import FirstOrderModuleExtension
+
+if TYPE_CHECKING:
+    from backpack.extensions import SumGradSquared
 
 
 class SGSBase(FirstOrderModuleExtension):
-    def __init__(self, derivatives, params=None):
-        self.derivatives = derivatives
-        self.N_axis = 0
-        super().__init__(params=params)
+    """Base class for extensions calculating sum_grad_squared."""
 
-    def bias(self, ext, module, g_inp, g_out, bpQuantities):
-        grad_batch = self.derivatives.bias_jac_t_mat_prod(
-            module, g_inp, g_out, g_out[0], sum_batch=False
-        )
-        return (grad_batch ** 2).sum(self.N_axis)
+    def __init__(self, derivatives: BaseParameterDerivatives, params: List[str] = None):
+        """Initialization.
 
-    def weight(self, ext, module, g_inp, g_out, bpQuantities):
-        grad_batch = self.derivatives.weight_jac_t_mat_prod(
-            module, g_inp, g_out, g_out[0], sum_batch=False
-        )
-        return (grad_batch ** 2).sum(self.N_axis)
+        For each parameter a function is initialized that is named like the parameter
+
+        Args:
+            derivatives: calculates the derivatives wrt parameters
+            params: list of parameter names
+        """
+        self.derivatives: BaseParameterDerivatives = derivatives
+        self.N_axis: int = 0
+        for param_str in params:
+            if not hasattr(self, param_str):
+                setattr(self, param_str, self._make_param_function(param_str))
+        super(SGSBase, self).__init__(params=params)
+
+    def _make_param_function(
+        self, param_str: str
+    ) -> Callable[[SumGradSquared, Module, Tuple[Tensor], Tuple[Tensor], None], Tensor]:
+        """Creates a function that calculates sum_grad_squared.
+
+        Args:
+            param_str: name of parameter
+
+        Returns:
+            function that calculates sum_grad_squared
+        """
+
+        def param_function(
+            ext: SumGradSquared,
+            module: Module,
+            g_inp: Tuple[Tensor],
+            g_out: Tuple[Tensor],
+            bpQuantities: None,
+        ) -> Tensor:
+            """Calculates sum_grad_squared with the help of derivatives object.
+
+            Args:
+                ext: extension that is used
+                module: module that performed forward pass
+                g_inp: input gradient tensors
+                g_out: output gradient tensors
+                bpQuantities: additional quantities for second order
+
+            Returns:
+                sum_grad_squared
+            """
+            grad_batch = getattr(self.derivatives, f"{param_str}_jac_t_mat_prod")(
+                module, g_inp, g_out, g_out[0], sum_batch=False
+            )
+            return (grad_batch ** 2).sum(self.N_axis)
+
+        return param_function

--- a/backpack/extensions/firstorder/variance/__init__.py
+++ b/backpack/extensions/firstorder/variance/__init__.py
@@ -1,4 +1,9 @@
+"""Defines backpropagation extension for variance: Variance.
+
+Defines module extension for each module.
+"""
 from torch.nn import (
+    RNN,
     Conv1d,
     Conv2d,
     Conv3d,
@@ -18,6 +23,7 @@ from . import (
     convtranspose2d,
     convtranspose3d,
     linear,
+    rnn,
 )
 
 
@@ -36,6 +42,10 @@ class Variance(BackpropExtension):
     """
 
     def __init__(self):
+        """Initialization.
+
+        Defines module extension for each module.
+        """
         super().__init__(
             savefield="variance",
             fail_mode="WARNING",
@@ -47,5 +57,6 @@ class Variance(BackpropExtension):
                 ConvTranspose1d: convtranspose1d.VarianceConvTranspose1d(),
                 ConvTranspose2d: convtranspose2d.VarianceConvTranspose2d(),
                 ConvTranspose3d: convtranspose3d.VarianceConvTranspose3d(),
+                RNN: rnn.VarianceRNN(),
             },
         )

--- a/backpack/extensions/firstorder/variance/rnn.py
+++ b/backpack/extensions/firstorder/variance/rnn.py
@@ -1,0 +1,20 @@
+"""Contains VarianceRNN."""
+from backpack.extensions.firstorder.gradient.rnn import GradRNN
+from backpack.extensions.firstorder.sum_grad_squared.rnn import SGSRNN
+from backpack.extensions.firstorder.variance.variance_base import VarianceBaseModule
+
+
+class VarianceRNN(VarianceBaseModule):
+    """Extension for RNN, calculating variance."""
+
+    def __init__(self):
+        """Initialization."""
+        super(VarianceRNN, self).__init__(
+            params=["bias_ih_l0", "bias_hh_l0", "weight_ih_l0", "weight_hh_l0"],
+            grad_extension=GradRNN(),
+            sgs_extension=SGSRNN(),
+        )
+
+    @staticmethod
+    def _get_axis_batch() -> int:
+        return 1

--- a/backpack/extensions/firstorder/variance/variance_base.py
+++ b/backpack/extensions/firstorder/variance/variance_base.py
@@ -1,30 +1,89 @@
+"""Contains VarianceBaseModule."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, List, Tuple
+
+from torch import Tensor
+from torch.nn import Module
+
 from backpack.extensions.firstorder.base import FirstOrderModuleExtension
+
+if TYPE_CHECKING:
+    from backpack.extensions import Variance
+    from backpack.extensions.firstorder.gradient.base import GradBaseModule
+    from backpack.extensions.firstorder.sum_grad_squared.sgs_base import SGSBase
 
 
 class VarianceBaseModule(FirstOrderModuleExtension):
-    def __init__(self, params, grad_extension, sgs_extension):
-        super().__init__(params=params)
-        self.grad_ext = grad_extension
-        self.sgs_ext = sgs_extension
+    """Base class for extensions calculating variance."""
+
+    def __init__(
+        self,
+        params: List[str],
+        grad_extension: GradBaseModule,
+        sgs_extension: SGSBase,
+    ):
+        """Initialization.
+
+        Creates a function named after each parameter.
+
+        Args:
+            params: list of parameter names
+            grad_extension: the extension calculating grad.
+            sgs_extension: the extension calculating squared_grad_sum.
+        """
+        self.grad_ext: GradBaseModule = grad_extension
+        self.sgs_ext: SGSBase = sgs_extension
+        for param_str in params:
+            if not hasattr(self, param_str):
+                setattr(self, param_str, self._make_param_function(param_str))
+        super(VarianceBaseModule, self).__init__(params=params)
 
     @staticmethod
-    def variance_from(grad, sgs, N):
+    def _variance_from(grad: Tensor, sgs: Tensor, N: int) -> Tensor:
         avgg_squared = (grad / N) ** 2
         avg_gsquared = sgs / N
         return avg_gsquared - avgg_squared
 
-    def bias(self, ext, module, g_inp, g_out, backproped):
-        N = g_out[0].shape[0]
-        return self.variance_from(
-            self.grad_ext.bias(ext, module, g_inp, g_out, backproped),
-            self.sgs_ext.bias(ext, module, g_inp, g_out, backproped),
-            N,
-        )
+    @staticmethod
+    def _get_axis_batch() -> int:
+        return 0
 
-    def weight(self, ext, module, g_inp, g_out, backproped):
-        N = g_out[0].shape[0]
-        return self.variance_from(
-            self.grad_ext.weight(ext, module, g_inp, g_out, backproped),
-            self.sgs_ext.weight(ext, module, g_inp, g_out, backproped),
-            N,
-        )
+    def _make_param_function(
+        self, param: str
+    ) -> Callable[[Variance, Module, Tuple[Tensor], Tuple[Tensor], None], Tensor]:
+        """Creates a function that calculates variance of grad_batch.
+
+        Args:
+            param(str): name of parameter
+
+        Returns:
+            function that calculates variance of grad_batch
+        """
+
+        def param_function(
+            ext: Variance,
+            module: Module,
+            g_inp: Tuple[Tensor],
+            g_out: Tuple[Tensor],
+            bpQuantities: None,
+        ) -> Tensor:
+            """Calculates variance with the help of derivatives object.
+
+            Args:
+                ext: extension that is used
+                module: module that performed forward pass
+                g_inp: input gradient tensors
+                g_out: output gradient tensors
+                bpQuantities: additional quantities for second order
+
+            Returns:
+                variance of the batch
+            """
+            return self._variance_from(
+                getattr(self.grad_ext, param)(ext, module, g_inp, g_out, bpQuantities),
+                getattr(self.sgs_ext, param)(ext, module, g_inp, g_out, bpQuantities),
+                g_out[0].shape[self._get_axis_batch()],
+            )
+
+        return param_function

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -1,7 +1,28 @@
+setup.py
+
 backpack/core/derivatives/basederivatives.py
 backpack/core/derivatives/rnn.py
 backpack/core/derivatives/shape_check.py
 backpack/core/derivatives/__init__.py
+
+backpack/extensions/firstorder/gradient/base.py
+backpack/extensions/firstorder/gradient/rnn.py
+backpack/extensions/firstorder/gradient/__init__.py
+backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+backpack/extensions/firstorder/batch_grad/rnn.py
+backpack/extensions/firstorder/batch_grad/__init__.py
+backpack/extensions/firstorder/variance/variance_base.py
+backpack/extensions/firstorder/variance/rnn.py
+backpack/extensions/firstorder/variance/__init__.py
+backpack/extensions/firstorder/sum_grad_squared/sgs_base.py
+backpack/extensions/firstorder/sum_grad_squared/rnn.py
+backpack/extensions/firstorder/sum_grad_squared/__init__.py
+backpack/extensions/firstorder/batch_l2_grad/rnn.py
+backpack/extensions/firstorder/batch_l2_grad/__init__.py
+# backpack/extensions/module_extension.py
+backpack/extensions/backprop_extension.py
+
+backpack/custom_module/
 
 test/core/derivatives/derivatives_test.py
 test/core/derivatives/__init__.py
@@ -12,5 +33,7 @@ test/core/derivatives/implementation/
 test/extensions/problem.py
 test/extensions/test_backprop_extension.py
 test/extensions/firstorder/firstorder_settings.py
+test/extensions/firstorder/batch_grad/batchgrad_settings.py
+# test/extensions/implementation/
 
 # docs_src/examples/use_cases/example_custom_module

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -19,7 +19,6 @@ backpack/extensions/firstorder/sum_grad_squared/rnn.py
 backpack/extensions/firstorder/sum_grad_squared/__init__.py
 backpack/extensions/firstorder/batch_l2_grad/rnn.py
 backpack/extensions/firstorder/batch_l2_grad/__init__.py
-# backpack/extensions/module_extension.py
 backpack/extensions/backprop_extension.py
 
 backpack/custom_module/
@@ -34,6 +33,3 @@ test/extensions/problem.py
 test/extensions/test_backprop_extension.py
 test/extensions/firstorder/firstorder_settings.py
 test/extensions/firstorder/batch_grad/batchgrad_settings.py
-# test/extensions/implementation/
-
-# docs_src/examples/use_cases/example_custom_module

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+"""Setup backpack."""
 from os import path
 
 from setuptools import find_packages, setup
@@ -43,5 +44,5 @@ setup(
     license=LICENSE,
     packages=PACKAGES,
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/test/extensions/firstorder/batch_grad/batchgrad_settings.py
+++ b/test/extensions/firstorder/batch_grad/batchgrad_settings.py
@@ -1,14 +1,11 @@
-"""Test configurations to test batch_grad
+"""Test configurations to test batch_grad.
 
 The tests are taken from `test.extensions.firstorder.firstorder_settings`, 
 but additional custom tests can be defined here by appending it to the list.
 """
-
 from test.extensions.firstorder.firstorder_settings import FIRSTORDER_SETTINGS
 
-BATCHGRAD_SETTINGS = []
-
 SHARED_SETTINGS = FIRSTORDER_SETTINGS
-LOCAL_SETTING = []
+LOCAL_SETTINGS = []
 
-BATCHGRAD_SETTINGS = SHARED_SETTINGS + LOCAL_SETTING
+BATCHGRAD_SETTINGS = SHARED_SETTINGS + LOCAL_SETTINGS

--- a/test/extensions/firstorder/firstorder_settings.py
+++ b/test/extensions/firstorder/firstorder_settings.py
@@ -166,10 +166,10 @@ FIRSTORDER_SETTINGS += [
     {
         "input_fn": lambda: torch.rand(8, 5, 6),
         "module_fn": lambda: Sequential(
-            Permute(dims=[1, 0, 2]),
+            Permute(1, 0, 2),
             RNN(input_size=6, hidden_size=3),
             ReduceTuple(index=0),
-            Permute(dims=[1, 2, 0]),
+            Permute(1, 2, 0),
         ),
         "loss_function_fn": lambda: torch.nn.CrossEntropyLoss(reduction="mean"),
         "target_fn": lambda: classification_targets((8, 5), 3),
@@ -177,10 +177,10 @@ FIRSTORDER_SETTINGS += [
     {
         "input_fn": lambda: torch.rand(8, 5, 6),
         "module_fn": lambda: Sequential(
-            Permute(dims=[1, 0, 2]),
+            Permute(1, 0, 2),
             RNN(input_size=6, hidden_size=3),
             ReduceTuple(index=0),
-            Permute(dims=[1, 2, 0]),
+            Permute(1, 2, 0),
             Flatten(),
         ),
         "loss_function_fn": lambda: torch.nn.MSELoss(),

--- a/test/extensions/firstorder/firstorder_settings.py
+++ b/test/extensions/firstorder/firstorder_settings.py
@@ -18,22 +18,25 @@ Optional entries:
     "device" [list(torch.device)]: List of devices to run the test on.
     "id_prefix" (str): Prefix to be included in the test name.
     "seed" (int): seed for the random number for torch.rand
-    "axis_batch (int): specifies the batch axis. Defaults to zero
 """
-
-
 from test.core.derivatives.utils import classification_targets, regression_targets
 from test.extensions.automated_settings import make_simple_cnn_setting
 
 import torch
 from torch.nn import (
+    RNN,
     Conv1d,
     Conv2d,
     Conv3d,
     ConvTranspose1d,
     ConvTranspose2d,
     ConvTranspose3d,
+    Flatten,
+    Sequential,
 )
+
+from backpack.custom_module.permute import Permute
+from backpack.custom_module.reduce_tuple import ReduceTuple
 
 FIRSTORDER_SETTINGS = []
 
@@ -153,4 +156,34 @@ FIRSTORDER_SETTINGS += [
     make_simple_cnn_setting(
         (3, 3, 2, 7, 7), ConvTranspose3d, (3, 2, 2, 4, 2, 0, 1, False)
     ),
+]
+
+###############################################################################
+#                         test setting: RNN Layers                            #
+###############################################################################
+
+FIRSTORDER_SETTINGS += [
+    {
+        "input_fn": lambda: torch.rand(8, 5, 6),
+        "module_fn": lambda: Sequential(
+            Permute(dims=[1, 0, 2]),
+            RNN(input_size=6, hidden_size=3),
+            ReduceTuple(index=0),
+            Permute(dims=[1, 2, 0]),
+        ),
+        "loss_function_fn": lambda: torch.nn.CrossEntropyLoss(reduction="mean"),
+        "target_fn": lambda: classification_targets((8, 5), 3),
+    },
+    {
+        "input_fn": lambda: torch.rand(8, 5, 6),
+        "module_fn": lambda: Sequential(
+            Permute(dims=[1, 0, 2]),
+            RNN(input_size=6, hidden_size=3),
+            ReduceTuple(index=0),
+            Permute(dims=[1, 2, 0]),
+            Flatten(),
+        ),
+        "loss_function_fn": lambda: torch.nn.MSELoss(),
+        "target_fn": lambda: regression_targets((8, 3 * 5)),
+    },
 ]

--- a/test/extensions/implementation/autograd.py
+++ b/test/extensions/implementation/autograd.py
@@ -16,7 +16,7 @@ class AutogradExtensions(ExtensionsImplementation):
         Returns:
             list[torch.Tensor]: batch_grads
         """
-        N = self.problem.input.shape[self.problem.axis_batch]
+        N = self.problem.input.shape[0]
         batch_grads = [
             torch.zeros(N, *p.size()).to(self.problem.device)
             for p in self.problem.model.parameters()

--- a/test/extensions/problem.py
+++ b/test/extensions/problem.py
@@ -48,7 +48,6 @@ def add_missing_defaults(setting):
         "id_prefix": "",
         "seed": 0,
         "device": get_available_devices(),
-        "axis_batch": 0,
     }
 
     for req in required:
@@ -78,7 +77,6 @@ class ExtensionsTestProblem:
         device,
         seed,
         id_prefix,
-        axis_batch,
     ):
         """Collection of information required to test extensions.
 
@@ -90,7 +88,6 @@ class ExtensionsTestProblem:
             device (torch.device): Device to run on.
             seed (int): Random seed.
             id_prefix (str): Extra string added to test id.
-            axis_batch (int): index of batch axis. Defaults to 0.
         """
         self.module_fn = module_fn
         self.input_fn = input_fn
@@ -100,7 +97,6 @@ class ExtensionsTestProblem:
         self.device = device
         self.seed = seed
         self.id_prefix = id_prefix
-        self.axis_batch = axis_batch
 
     def set_up(self):
         """Set up problem from settings."""
@@ -151,17 +147,9 @@ class ExtensionsTestProblem:
             target = self.target.clone().detach()
         else:
             target = self.target.clone()[sample_idx].unsqueeze(0).detach()
-            input = self.input.split(1, dim=self.axis_batch)[sample_idx].detach()
+            input = self.input.split(1, dim=0)[sample_idx].detach()
 
         output = self.model(input)
-        if isinstance(output, tuple):
-            output = output[0]
-
-        if self.axis_batch != 0:
-            # Note: This inserts a new operation into the computation graph.
-            # In second order extensions, breaks backpropagation of additional
-            # information.
-            output = output.transpose(0, self.axis_batch)
 
         loss = self.loss_function(output, target)
 


### PR DESCRIPTION
Add support for all first order extensions for RNN.
The ``axis_batch`` variable is removed from test problems in extensions.
Instead, modules ``Permute`` and ``ReduceTuple`` are introduced and can be used in a ``Sequential`` module.
Python version bumped to 3.7 because ``from __future__ import annotations`` is used.