### PR TITLE
[utils] Support groups ≠ 1 in ConvNd extract_weight_diagonal

### DIFF
--- a/backpack/utils/conv.py
+++ b/backpack/utils/conv.py
@@ -55,13 +55,14 @@ def extract_weight_diagonal(module, unfolded_input, S, N, sum_batch=True):
         unfolded_input (torch.Tensor): Unfolded input to the convolution. Shape must
             follow the conventions of ``torch.nn.Unfold``.
         S (torch.Tensor): Backpropagated (symmetric factorization) of the loss Hessian.
-            Has shape ``[V, *module.output.shape]``.
-        N (int): Convolution dimension
+            Has shape ``(V, *module.output.shape)``.
+        N (int): Convolution dimension.
         sum_batch (bool, optional): Sum out the batch dimension of the weight diagonals.
+            Default value: ``True``.
 
     Returns:
         torch.Tensor: Per-sample weight diagonal if ``sum_batch=False`` (shape
-            ``[N, module.weight.shape]`` with batch size ``N``) or summed weight
+            ``(N, module.weight.shape)`` with batch size ``N``) or summed weight
             diagonal if ``sum_batch=True`` (shape ``module.weight.shape``).
     """
     S = rearrange(S, "v n (g c) ... -> v n g c (...)", g=module.groups)

--- a/backpack/utils/conv.py
+++ b/backpack/utils/conv.py
@@ -46,25 +46,37 @@ def separate_channels_and_pixels(module, tensor):
     return rearrange(tensor, "v n c ... -> v n c (...)")
 
 
-def extract_weight_diagonal(module, input, grad_output, N, sum_batch=True):
+def extract_weight_diagonal(module, unfolded_input, S, N, sum_batch=True):
+    """Extract diagonal of ``(Jᵀ S) (Jᵀ S)ᵀ`` where ``J`` is the weight Jacobian.
+
+    Args:
+        module (torch.nn.Conv1d or torch.nn.Conv2d or torch.nn.Conv3d): Convolution
+            layer for which the diagonal is extracted w.r.t. the weight.
+        unfolded_input (torch.Tensor): Unfolded input to the convolution. Shape must
+            follow the conventions of ``torch.nn.Unfold``.
+        S (torch.Tensor): Backpropagated (symmetric factorization) of the loss Hessian.
+            Has shape ``[V, *module.output.shape]``.
+        N (int): Convolution dimension
+        sum_batch (bool, optional): Sum out the batch dimension of the weight diagonals.
+
+    Returns:
+        torch.Tensor: Per-sample weight diagonal if ``sum_batch=False`` (shape
+            ``[N, module.weight.shape]`` with batch size ``N``) or summed weight
+            diagonal if ``sum_batch=True`` (shape ``module.weight.shape``).
     """
-    input must be the unfolded input to the convolution (see unfold_func)
-    and grad_output the backpropagated gradient
-    """
-    grad_output = rearrange(
-        grad_output, "v n (g c) ... -> v n g c (...)", g=module.groups
-    )
-    input = rearrange(input, "n (g c) k -> n g c k", g=module.groups)
-    AX = einsum("ngkl,vngml->vngmk", (input, grad_output))
+    S = rearrange(S, "v n (g c) ... -> v n g c (...)", g=module.groups)
+    unfolded_input = rearrange(unfolded_input, "n (g c) k -> n g c k", g=module.groups)
+
+    JS = einsum("ngkl,vngml->vngmk", (unfolded_input, S))
 
     sum_dims = [0, 1] if sum_batch else [0]
-    weight_diagonal = (AX ** 2).sum(sum_dims)
+    out_shape = (
+        module.weight.shape if sum_batch else (JS.shape[1], *module.weight.shape)
+    )
 
-    if sum_batch:
-        return weight_diagonal.reshape(module.weight.shape)
-    else:
-        N = AX.shape[1]
-        return weight_diagonal.reshape(N, *module.weight.shape)
+    weight_diagonal = JS.pow_(2).sum(sum_dims).reshape(out_shape)
+
+    return weight_diagonal
 
 
 def extract_bias_diagonal(module, sqrt, N, sum_batch=True):

--- a/backpack/utils/conv.py
+++ b/backpack/utils/conv.py
@@ -52,7 +52,7 @@ def extract_weight_diagonal(module, input, grad_output, N, sum_batch=True):
     and grad_output the backpropagated gradient
     """
     grad_output = rearrange(
-        grad_output, "v n (g c) ... -> v n g c ...", g=module.groups
+        grad_output, "v n (g c) ... -> v n g c (...)", g=module.groups
     )
     input = rearrange(input, "n (g c) k -> n g c k", g=module.groups)
     AX = einsum("ngkl,vngml->vngmk", (input, grad_output))

--- a/test/extensions/secondorder/secondorder_settings.py
+++ b/test/extensions/secondorder/secondorder_settings.py
@@ -218,6 +218,8 @@ SECONDORDER_SETTINGS += [
 _GROUP_CONV_SETTINGS = [
     # last number is groups
     make_simple_cnn_setting((3, 6, 7), Conv1d, (6, 4, 2, 1, 0, 1, 2)),
+    make_simple_cnn_setting((3, 6, 7, 5), Conv2d, (6, 3, 2, 1, 0, 1, 3)),
+    make_simple_cnn_setting((3, 4, 7, 5, 6), Conv3d, (4, 2, 2, 1, 0, 2, 2)),
 ]
 
 SECONDORDER_SETTINGS += _GROUP_CONV_SETTINGS

--- a/test/extensions/secondorder/secondorder_settings.py
+++ b/test/extensions/secondorder/secondorder_settings.py
@@ -214,3 +214,10 @@ SECONDORDER_SETTINGS += [
         (3, 3, 2, 7, 7), ConvTranspose3d, (3, 2, 2, 4, 2, 0, 1, False)
     ),
 ]
+
+_GROUP_CONV_SETTINGS = [
+    # last number is groups
+    make_simple_cnn_setting((3, 6, 7), Conv1d, (6, 4, 2, 1, 0, 1, 2)),
+]
+
+SECONDORDER_SETTINGS += _GROUP_CONV_SETTINGS


### PR DESCRIPTION
This fixes  `groups ≠ 1` in diagonal curvature extensions. 

Resolves https://github.com/fKunstner/backpack-discuss/issues/86.

