### PR TITLE
 [utils] Support groups ≠ 1 in ConvTransposeNd extract_weight_diagonal

### DIFF
--- a/backpack/utils/conv.py
+++ b/backpack/utils/conv.py
@@ -102,7 +102,7 @@ def unfold_by_conv(input, module):
     """Return the unfolded input using convolution"""
     N, C_in = input.shape[0], input.shape[1]
     kernel_size = module.kernel_size
-    kernel_size_numel = int(torch.prod(torch.Tensor(kernel_size)))
+    kernel_size_numel = module.weight.shape[2:].numel()
 
     def make_weight():
         weight = torch.zeros(kernel_size_numel, 1, *kernel_size)

--- a/backpack/utils/conv_transpose.py
+++ b/backpack/utils/conv_transpose.py
@@ -1,3 +1,5 @@
+"""Utility functions for extracting transpose convolution BackPACK quantities."""
+
 import torch
 from einops import rearrange
 from torch import einsum
@@ -6,8 +8,7 @@ from torch.nn.functional import conv_transpose1d, conv_transpose2d, conv_transpo
 
 def get_weight_gradient_factors(input, grad_out, module, N):
     M, C_in = input.shape[0], input.shape[1]
-    kernel_size = module.kernel_size
-    kernel_size_numel = int(torch.prod(torch.Tensor(kernel_size)))
+    kernel_size_numel = module.weight.shape[2:].numel()
 
     X = unfold_by_conv_transpose(input, module).reshape(M, C_in * kernel_size_numel, -1)
     dE_dY = rearrange(grad_out, "n c ... -> n c (...)")
@@ -88,7 +89,7 @@ def unfold_by_conv_transpose(input, module):
     """
     N, C_in = input.shape[0], input.shape[1]
     kernel_size = module.kernel_size
-    kernel_size_numel = int(torch.prod(torch.Tensor(kernel_size)))
+    kernel_size_numel = module.weight.shape[2:].numel()
 
     def make_weight():
         weight = torch.zeros(1, kernel_size_numel, *kernel_size)

--- a/test/extensions/secondorder/secondorder_settings.py
+++ b/test/extensions/secondorder/secondorder_settings.py
@@ -222,6 +222,12 @@ _GROUP_CONV_SETTINGS = [
     make_simple_cnn_setting((3, 4, 7, 5, 6), Conv3d, (4, 2, 2, 1, 0, 2, 2)),
     # number before bool is groups
     make_simple_cnn_setting((3, 3, 8), ConvTranspose1d, (3, 6, 2, 4, 2, 0, 3, True, 3)),
+    make_simple_cnn_setting(
+        (3, 2, 9, 9), ConvTranspose2d, (2, 4, 2, 1, 0, 0, 2, True, 2)
+    ),
+    make_simple_cnn_setting(
+        (3, 2, 3, 5, 5), ConvTranspose3d, (2, 4, 2, 2, 2, 0, 2, True, 2)
+    ),
 ]
 
 SECONDORDER_SETTINGS += _GROUP_CONV_SETTINGS

--- a/test/extensions/secondorder/secondorder_settings.py
+++ b/test/extensions/secondorder/secondorder_settings.py
@@ -221,12 +221,12 @@ _GROUP_CONV_SETTINGS = [
     make_simple_cnn_setting((3, 6, 7, 5), Conv2d, (6, 3, 2, 1, 0, 1, 3)),
     make_simple_cnn_setting((3, 4, 7, 5, 6), Conv3d, (4, 2, 2, 1, 0, 2, 2)),
     # number before bool is groups
-    make_simple_cnn_setting((3, 3, 8), ConvTranspose1d, (3, 6, 2, 4, 2, 0, 3, True, 3)),
+    make_simple_cnn_setting((3, 6, 8), ConvTranspose1d, (6, 3, 2, 4, 2, 0, 3, True, 3)),
     make_simple_cnn_setting(
-        (3, 2, 9, 9), ConvTranspose2d, (2, 4, 2, 1, 0, 0, 2, True, 2)
+        (3, 4, 9, 9), ConvTranspose2d, (4, 2, 2, 1, 0, 0, 2, True, 2)
     ),
     make_simple_cnn_setting(
-        (3, 2, 3, 5, 5), ConvTranspose3d, (2, 4, 2, 2, 2, 0, 2, True, 2)
+        (3, 4, 3, 5, 5), ConvTranspose3d, (4, 2, (2, 2, 1), 2, 2, 0, 2, True, 2)
     ),
 ]
 

--- a/test/extensions/secondorder/secondorder_settings.py
+++ b/test/extensions/secondorder/secondorder_settings.py
@@ -220,6 +220,8 @@ _GROUP_CONV_SETTINGS = [
     make_simple_cnn_setting((3, 6, 7), Conv1d, (6, 4, 2, 1, 0, 1, 2)),
     make_simple_cnn_setting((3, 6, 7, 5), Conv2d, (6, 3, 2, 1, 0, 1, 3)),
     make_simple_cnn_setting((3, 4, 7, 5, 6), Conv3d, (4, 2, 2, 1, 0, 2, 2)),
+    # number before bool is groups
+    make_simple_cnn_setting((3, 3, 8), ConvTranspose1d, (3, 6, 2, 4, 2, 0, 3, True, 3)),
 ]
 
 SECONDORDER_SETTINGS += _GROUP_CONV_SETTINGS

--- a/test/utils/test_conv.py
+++ b/test/utils/test_conv.py
@@ -34,9 +34,7 @@ def convolution_with_unfold(input, module):
     C_out = output_shape[1]
     spatial_out_size = output_shape[2:]
     spatial_out_numel = spatial_out_size.numel()
-
-    kernel_size = module.kernel_size
-    kernel_size_numel = int(torch.prod(torch.Tensor(kernel_size)))
+    kernel_size_numel = module.weight.shape[2:].numel()
 
     G = module.groups
 

--- a/test/utils/test_conv_transpose.py
+++ b/test/utils/test_conv_transpose.py
@@ -27,9 +27,7 @@ def conv_transpose_with_unfold(input, module):
     C_out = output_shape[1]
     spatial_out_size = output_shape[2:]
     spatial_out_numel = spatial_out_size.numel()
-
-    kernel_size = module.kernel_size
-    kernel_size_numel = int(torch.prod(torch.Tensor(kernel_size)))
+    kernel_size_numel = module.weight.shape[2:].numel()
 
     G = module.groups
 


### PR DESCRIPTION
This fixes groups ≠ 1 in diagonal curvature extensions for transpose
convolutions.

Resolves https://github.com/fKunstner/backpack-discuss/issues/87.
Resolves https://github.com/fKunstner/backpack-discuss/issues/95