### PR TITLE
[FIX] PyPI release of `1.3.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ pip install backpack-for-pytorch
 
 #
 ## Contributing
-BackPACK is actively being developed.
+BackPACK is actively being developed. 
 We are appreciating any help.
 If you are considering to contribute, do not hesitate to contact us.
 An overview of the development procedure is provided in the [developer `README`](https://github.com/f-dangel/backpack/blob/master/README-dev.md).
 
 ## How to cite
-If you are using BackPACK, consider citing the [paper](https://openreview.net/forum?id=BJlrF24twB)
+If you are using BackPACK, consider citing the [paper](https://openreview.net/forum?id=BJlrF24twB) 
 ```
 @inproceedings{dangel2020backpack,
     title     = {Back{PACK}: Packing more into Backprop},
@@ -47,3 +47,4 @@ If you are using BackPACK, consider citing the [paper](https://openreview.net/fo
 ```
 
 ###### _BackPACK is not endorsed by or affiliated with Facebook, Inc. PyTorch, the PyTorch logo and any related marks are trademarks of Facebook, Inc._
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Provided quantities include:
 
 
 ## Installation
-Assuming you have `torch` (with `torchvision`) installed, run
 ```bash
 pip install backpack-for-pytorch
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Provided quantities include:
 
 
 ## Installation
+Assuming you have `torch` (with `torchvision`) installed, run
 ```bash
 pip install backpack-for-pytorch
 ```
@@ -29,13 +30,13 @@ pip install backpack-for-pytorch
 
 #
 ## Contributing
-BackPACK is actively being developed. 
+BackPACK is actively being developed.
 We are appreciating any help.
 If you are considering to contribute, do not hesitate to contact us.
 An overview of the development procedure is provided in the [developer `README`](https://github.com/f-dangel/backpack/blob/master/README-dev.md).
 
 ## How to cite
-If you are using BackPACK, consider citing the [paper](https://openreview.net/forum?id=BJlrF24twB) 
+If you are using BackPACK, consider citing the [paper](https://openreview.net/forum?id=BJlrF24twB)
 ```
 @inproceedings{dangel2020backpack,
     title     = {Back{PACK}: Packing more into Backprop},
@@ -47,4 +48,3 @@ If you are using BackPACK, consider citing the [paper](https://openreview.net/fo
 ```
 
 ###### _BackPACK is not endorsed by or affiliated with Facebook, Inc. PyTorch, the PyTorch logo and any related marks are trademarks of Facebook, Inc._
-

--- a/makefile
+++ b/makefile
@@ -121,6 +121,7 @@ install-lint:
 
 install-test:
 	@pip install -e .[test]
+	@pip install git+https://git@github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab
 
 install-docs:
 	@pip install -e .[docs]

--- a/makefile
+++ b/makefile
@@ -114,16 +114,17 @@ format-check-partial: black-check isort-check flake8 pydocstyle-check-partial da
 # Installation
 
 install:
+	@pip install torch torchvision
 	@pip install -e .
 
-install-lint:
+install-lint: install
 	@pip install -e .[lint]
 
-install-test:
+install-test: install
 	@pip install -e .[test]
 	@pip install git+https://git@github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab
 
-install-docs:
+install-docs: install
 	@pip install -e .[docs]
 
 install-dev: install-lint install-test install-docs

--- a/makefile
+++ b/makefile
@@ -116,14 +116,14 @@ format-check-partial: black-check isort-check flake8 pydocstyle-check-partial da
 install:
 	@pip install -e .
 
-install-lint: install
+install-lint:
 	@pip install -e .[lint]
 
-install-test: install
+install-test:
 	@pip install -e .[test]
 	@pip install git+https://git@github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab
 
-install-docs: install
+install-docs:
 	@pip install -e .[docs]
 
 install-dev: install-lint install-test install-docs

--- a/makefile
+++ b/makefile
@@ -114,7 +114,6 @@ format-check-partial: black-check isort-check flake8 pydocstyle-check-partial da
 # Installation
 
 install:
-	@pip install torch torchvision
 	@pip install -e .
 
 install-lint: install

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ test =
     pytest-optional-tests >= 0.1.1
     pytest-cov
     coveralls
-    pytorch_memlab @ git+https://git@github.com/Stonesjtu/pytorch_memlab.git@6ab5fab#egg=pytorch_memlab
 
 # Dependencies needed for linting (semicolon/line-separated)
 lint =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,7 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    torch
-    torchvision
-    einops
+    einops>=0.3.0
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,9 @@ install_requires =
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6
 
+[options.packages.find]
+exclude = test*
+
 ###############################################################################
 #                           Development dependencies                          #
 ###############################################################################

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,9 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    torch >= 1.6.0, < 2.0.0
-    torchvision >= 0.7.0, < 1.0.0
-    einops >= 0.3.0, < 1.0.0
+    torch>=1.6.0
+    torchvision>=0.7.0
+    einops>=0.3.0
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6
 
@@ -52,9 +52,9 @@ exclude = test*
 # Dependencies needed to run the tests  (semicolon/line-separated)
 test =
     scipy
-    pytest >= 4.5.0, < 5.0.0
-    pytest-benchmark >= 3.2.2, < 4.0.0
-    pytest-optional-tests >= 0.1.1
+    pytest>=4.5.0
+    pytest-benchmark>= 3.2.2
+    pytest-optional-tests>= 0.1.1
     pytest-cov
     coveralls
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,9 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    torch >=1.6.0
-    torchvision >=0.7.0
-    einops >=0.3.0
+    torch >= 1.6.0, < 2.0.0
+    torchvision >= 0.7.0, < 1.0.0
+    einops >= 0.3.0, < 1.0.0
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6
 
@@ -52,9 +52,9 @@ exclude = test*
 # Dependencies needed to run the tests  (semicolon/line-separated)
 test =
     scipy
-    pytest >=4.5.0
-    pytest-benchmark >=3.2.2
-    pytest-optional-tests >=0.1.1
+    pytest >= 4.5.0, < 5.0.0
+    pytest-benchmark >= 3.2.2, < 4.0.0
+    pytest-optional-tests >= 0.1.1
     pytest-cov
     coveralls
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,9 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    torch>=1.6.0
-    torchvision
-    einops>=0.3.0
+    torch >=1.6.0
+    torchvision >=0.7.0
+    einops >=0.3.0
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6
 
@@ -52,9 +52,9 @@ exclude = test*
 # Dependencies needed to run the tests  (semicolon/line-separated)
 test =
     scipy
-    pytest>=4.5.0
-    pytest-benchmark>= 3.2.2
-    pytest-optional-tests>= 0.1.1
+    pytest >=4.5.0
+    pytest-benchmark >=3.2.2
+    pytest-optional-tests >=0.1.1
     pytest-cov
     coveralls
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,9 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    torch>=1.6.0
-    torchvision>=0.7.0
-    einops>=0.3.0
+    torch
+    torchvision
+    einops
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
+    torch>=1.6.0
+    torchvision
     einops>=0.3.0
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@
 [metadata]
 name = backpack-for-pytorch
 author = Felix Dangel, Frederik Kunstner
-URL = "https://github.com/f-dangel/backpack"
+url = https://github.com/f-dangel/backpack
 description = BackPACK: Packing more into backprop
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM


### PR DESCRIPTION
There were some unforeseeable problems when trying to push to PyPI:
- The `test` folder was added to the package
- Pushing was not possible due to the GitHub dependency of `pytorch_memlab`
- Incorrectly specified URL in metadata

Auxiliary:
- Trying to install from `testpypi` raised errors of the following form:
  ```bash
    ERROR: Could not find a version that satisfies the requirement einops>=0.3.0 (from backpack-for-pytorch) 
    ERROR: No matching distribution found for einops>=0.3.0
  ```
  I tried some fixes, but ultimately gave up. When I install the dependencies manually with `pip` before invoking
  the `testpypi` install command, it seems to work. Thus I don't understand why the version specification fails
  with the above error.