### PR TITLE
[ADD] `SqrtGGNExact` extension

### DIFF
--- a/backpack/extensions/__init__.py
+++ b/backpack/extensions/__init__.py
@@ -13,6 +13,7 @@ from .secondorder import (
     DiagGGNExact,
     DiagGGNMC,
     DiagHessian,
+    SqrtGGNExact,
 )
 
 __all__ = [
@@ -33,4 +34,5 @@ __all__ = [
     "BatchDiagGGNMC",
     "DiagHessian",
     "BatchDiagHessian",
+    "SqrtGGNExact",
 ]

--- a/backpack/extensions/secondorder/__init__.py
+++ b/backpack/extensions/secondorder/__init__.py
@@ -17,11 +17,20 @@ The implemented extensions are
   :func:`KFRA <backpack.extensions.KFRA>`,
   :func:`KFLR <backpack.extensions.KFLR>`.
 - The diagonal of the Hessian :func:`DiagHessian <backpack.extensions.DiagHessian>`
+- The symmetric (square root) factorization of the GGN/Fisher information,
+  using exact computation
+  (:func:`SqrtGGNExact <backpack.extensions.SqrtGGNExact>`)
 """
 
-from .diag_ggn import BatchDiagGGNExact, BatchDiagGGNMC, DiagGGNExact, DiagGGNMC
-from .diag_hessian import BatchDiagHessian, DiagHessian
-from .hbp import HBP, KFAC, KFLR, KFRA
+from backpack.extensions.secondorder.diag_ggn import (
+    BatchDiagGGNExact,
+    BatchDiagGGNMC,
+    DiagGGNExact,
+    DiagGGNMC,
+)
+from backpack.extensions.secondorder.diag_hessian import BatchDiagHessian, DiagHessian
+from backpack.extensions.secondorder.hbp import HBP, KFAC, KFLR, KFRA
+from backpack.extensions.secondorder.sqrt_ggn import SqrtGGNExact
 
 __all__ = [
     "DiagGGNExact",
@@ -34,4 +43,5 @@ __all__ = [
     "KFLR",
     "KFRA",
     "HBP",
+    "SqrtGGNExact",
 ]

--- a/backpack/extensions/secondorder/sqrt_ggn/__init__.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/__init__.py
@@ -87,6 +87,14 @@ class SqrtGGN(BackpropExtension):
             },
         )
 
+    def get_loss_hessian_strategy(self) -> str:
+        """Return the strategy used to represent the backpropagated loss Hessian.
+
+        Returns:
+            Loss Hessian strategy.
+        """
+        return self.loss_hessian_strategy
+
 
 class SqrtGGNExact(SqrtGGN):
     """Exact matrix square root of the generalized Gauss-Newton/Fisher.

--- a/backpack/extensions/secondorder/sqrt_ggn/__init__.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/__init__.py
@@ -123,4 +123,5 @@ class SqrtGGNExact(SqrtGGN):
     """
 
     def __init__(self):
-        super().__init__(LossHessianStrategy.EXACT, "diag_ggn_exact")
+        """Use exact loss Hessian and set savefield to ``sqrt_ggn_exact``."""
+        super().__init__(LossHessianStrategy.EXACT, "sqrt_ggn_exact")

--- a/backpack/extensions/secondorder/sqrt_ggn/__init__.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/__init__.py
@@ -1,0 +1,126 @@
+"""Defines base class and extensions for computing the GGN/Fisher matrix square root."""
+
+from torch.nn import (
+    ELU,
+    SELU,
+    AvgPool1d,
+    AvgPool2d,
+    AvgPool3d,
+    Conv1d,
+    Conv2d,
+    Conv3d,
+    ConvTranspose1d,
+    ConvTranspose2d,
+    ConvTranspose3d,
+    CrossEntropyLoss,
+    Dropout,
+    Flatten,
+    LeakyReLU,
+    Linear,
+    LogSigmoid,
+    MaxPool1d,
+    MaxPool2d,
+    MaxPool3d,
+    MSELoss,
+    ReLU,
+    Sigmoid,
+    Tanh,
+    ZeroPad2d,
+)
+
+from backpack.extensions.backprop_extension import BackpropExtension
+from backpack.extensions.secondorder.hbp import LossHessianStrategy
+from backpack.extensions.secondorder.sqrt_ggn import (
+    activations,
+    convnd,
+    convtransposend,
+    dropout,
+    flatten,
+    linear,
+    losses,
+    padding,
+    pooling,
+)
+
+
+class SqrtGGN(BackpropExtension):
+    """Base class for extensions that compute the GGN/Fisher matrix square root."""
+
+    VALID_LOSS_HESSIAN_STRATEGIES = [
+        LossHessianStrategy.EXACT,
+        LossHessianStrategy.SAMPLING,
+    ]
+
+    def __init__(self, loss_hessian_strategy: str, savefield: str):
+        """Store approximation for backpropagated object and where to save the result.
+
+        Args:
+            loss_hessian_strategy: Which approximation is used for the backpropagated
+                loss Hessian. Must be ``'exact'`` or ``'sampling'``.
+            savefield: Attribute under which the quantity is saved in a parameter.
+
+        Raises:
+            ValueError: For invalid choices of ``loss_hessian_strategy``.
+        """
+        if loss_hessian_strategy not in self.VALID_LOSS_HESSIAN_STRATEGIES:
+            raise ValueError(
+                "Unknown hessian strategy: {}".format(loss_hessian_strategy)
+                + "Valid strategies: [{}]".format(self.VALID_LOSS_HESSIAN_STRATEGIES)
+            )
+
+        self.loss_hessian_strategy = loss_hessian_strategy
+        super().__init__(
+            savefield=savefield,
+            fail_mode="ERROR",
+            module_exts={
+                MSELoss: losses.SqrtGGNMSELoss(),
+                CrossEntropyLoss: losses.SqrtGGNCrossEntropyLoss(),
+                Linear: linear.SqrtGGNLinear(),
+                MaxPool1d: pooling.SqrtGGNMaxPool1d(),
+                MaxPool2d: pooling.SqrtGGNMaxPool2d(),
+                AvgPool1d: pooling.SqrtGGNAvgPool1d(),
+                MaxPool3d: pooling.SqrtGGNMaxPool3d(),
+                AvgPool2d: pooling.SqrtGGNAvgPool2d(),
+                AvgPool3d: pooling.SqrtGGNAvgPool3d(),
+                ZeroPad2d: padding.SqrtGGNZeroPad2d(),
+                Conv1d: convnd.SqrtGGNConv1d(),
+                Conv2d: convnd.SqrtGGNConv2d(),
+                Conv3d: convnd.SqrtGGNConv3d(),
+                ConvTranspose1d: convtransposend.SqrtGGNConvTranspose1d(),
+                ConvTranspose2d: convtransposend.SqrtGGNConvTranspose2d(),
+                ConvTranspose3d: convtransposend.SqrtGGNConvTranspose3d(),
+                Dropout: dropout.SqrtGGNDropout(),
+                Flatten: flatten.SqrtGGNFlatten(),
+                ReLU: activations.SqrtGGNReLU(),
+                Sigmoid: activations.SqrtGGNSigmoid(),
+                Tanh: activations.SqrtGGNTanh(),
+                LeakyReLU: activations.SqrtGGNLeakyReLU(),
+                LogSigmoid: activations.SqrtGGNLogSigmoid(),
+                ELU: activations.SqrtGGNELU(),
+                SELU: activations.SqrtGGNSELU(),
+            },
+        )
+
+
+class SqrtGGNExact(SqrtGGN):
+    """Exact matrix square root of the generalized Gauss-Newton/Fisher.
+
+    Uses the exact Hessian of the loss w.r.t. the model output.
+
+    Stores the output in :code:`sqrt_ggn_exact`, has shape ``[C, N, param.shape]``,
+    where ``C`` is the model output dimension (number of classes for classification
+    problems) and ``N`` is the batch size.
+
+    For a faster but less precise alternative, see
+    :py:meth:`backpack.extensions.SqrtGGNMC`.
+
+    .. note::
+
+        (Relation to the GGN/Fisher) For each parameter, ``param.sqrt_ggn_exact``,
+        can be viewed as a ``[C * N, param.numel()]`` matrix. Concatenating this
+        matrix over all parameters results in a matrix ``Vᵀ``, which
+        is the GGN/Fisher's matrix square root, i.e. ``G = V Vᵀ``.
+    """
+
+    def __init__(self):
+        super().__init__(LossHessianStrategy.EXACT, "diag_ggn_exact")

--- a/backpack/extensions/secondorder/sqrt_ggn/__init__.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/__init__.py
@@ -102,7 +102,7 @@ class SqrtGGNExact(SqrtGGN):
 
     .. note::
 
-        (Relation to the GGN/Fisher) For each parameter, ``param.sqrt_ggn_exact``,
+        (Relation to the GGN/Fisher) For each parameter, ``param.sqrt_ggn_exact``
         can be viewed as a ``[C * N, param.numel()]`` matrix. Concatenating this
         matrix over all parameters results in a matrix ``Vᵀ``, which
         is the GGN/Fisher's matrix square root, i.e. ``G = V Vᵀ``.

--- a/backpack/extensions/secondorder/sqrt_ggn/__init__.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/__init__.py
@@ -46,11 +46,6 @@ from backpack.extensions.secondorder.sqrt_ggn import (
 class SqrtGGN(BackpropExtension):
     """Base class for extensions that compute the GGN/Fisher matrix square root."""
 
-    VALID_LOSS_HESSIAN_STRATEGIES = [
-        LossHessianStrategy.EXACT,
-        LossHessianStrategy.SAMPLING,
-    ]
-
     def __init__(self, loss_hessian_strategy: str, savefield: str):
         """Store approximation for backpropagated object and where to save the result.
 
@@ -58,16 +53,7 @@ class SqrtGGN(BackpropExtension):
             loss_hessian_strategy: Which approximation is used for the backpropagated
                 loss Hessian. Must be ``'exact'`` or ``'sampling'``.
             savefield: Attribute under which the quantity is saved in a parameter.
-
-        Raises:
-            ValueError: For invalid choices of ``loss_hessian_strategy``.
         """
-        if loss_hessian_strategy not in self.VALID_LOSS_HESSIAN_STRATEGIES:
-            raise ValueError(
-                "Unknown hessian strategy: {}".format(loss_hessian_strategy)
-                + "Valid strategies: [{}]".format(self.VALID_LOSS_HESSIAN_STRATEGIES)
-            )
-
         self.loss_hessian_strategy = loss_hessian_strategy
         super().__init__(
             savefield=savefield,

--- a/backpack/extensions/secondorder/sqrt_ggn/activations.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/activations.py
@@ -1,0 +1,65 @@
+"""Contains extensions for activation layers used by ``SqrtGGN{Exact, MC}``."""
+from backpack.core.derivatives.elu import ELUDerivatives
+from backpack.core.derivatives.leakyrelu import LeakyReLUDerivatives
+from backpack.core.derivatives.logsigmoid import LogSigmoidDerivatives
+from backpack.core.derivatives.relu import ReLUDerivatives
+from backpack.core.derivatives.selu import SELUDerivatives
+from backpack.core.derivatives.sigmoid import SigmoidDerivatives
+from backpack.core.derivatives.tanh import TanhDerivatives
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
+
+
+class SqrtGGNReLU(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.ReLU`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.ReLU`` module."""
+        super().__init__(ReLUDerivatives())
+
+
+class SqrtGGNSigmoid(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.Sigmoid`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.Sigmoid`` module."""
+        super().__init__(SigmoidDerivatives())
+
+
+class SqrtGGNTanh(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.Tanh`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.Tanh`` module."""
+        super().__init__(TanhDerivatives())
+
+
+class SqrtGGNELU(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.ELU`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.ELU`` module."""
+        super().__init__(ELUDerivatives())
+
+
+class SqrtGGNSELU(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.SELU`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.SELU`` module."""
+        super().__init__(SELUDerivatives())
+
+
+class SqrtGGNLeakyReLU(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.LeakyReLU`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.LeakyReLU`` module."""
+        super().__init__(LeakyReLUDerivatives())
+
+
+class SqrtGGNLogSigmoid(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.LogSigmoid`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.LogSigmoid`` module."""
+        super().__init__(LogSigmoidDerivatives())

--- a/backpack/extensions/secondorder/sqrt_ggn/base.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/base.py
@@ -1,5 +1,4 @@
 """Contains base class for ``SqrtGGN{Exact, MC}`` module extensions."""
-
 from typing import Any, Callable, List, Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/secondorder/sqrt_ggn/base.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/base.py
@@ -1,0 +1,78 @@
+"""Contains base class for ``SqrtGGN{Exact, MC}`` module extensions."""
+
+from typing import Any, Callable, List, Tuple, Union
+
+from torch import Tensor
+from torch.nn import Module
+
+from backpack.core.derivatives.basederivatives import (
+    BaseDerivatives,
+    BaseParameterDerivatives,
+)
+from backpack.extensions.mat_to_mat_jac_base import MatToJacMat
+
+
+class SqrtGGNBaseModule(MatToJacMat):
+    """Base module extension for ``SqrtGGN{Exact, MC}``."""
+
+    def __init__(
+        self,
+        derivatives: Union[BaseParameterDerivatives, BaseDerivatives],
+        params: List[str] = None,
+    ):
+        """Store parameter names and derivatives.
+
+        Sets up methods that extract the GGN/Fisher matrix square root for the
+        passed parameters, unless these methods are overwritten by a child class.
+
+        Args:
+            derivatives: derivatives object.
+            params: List of parameter names. Defaults to None.
+        """
+        super().__init__(derivatives, params=params)
+
+        if params is not None:
+            for param_str in params:
+                if not hasattr(self, param_str):
+                    setattr(self, param_str, self._make_param_function(param_str))
+
+    # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
+    # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
+    def _make_param_function(
+        self, param_str: str
+    ) -> Callable[[Any, Module, Tuple[Tensor], Tuple[Tensor], Tensor], Tensor]:
+        """Create a function that computes the GGN/Fisher square root for a parameter.
+
+        Args:
+            param_str: name of parameter
+
+        Returns:
+            Function that computes the GGN/Fisher matrix square root.
+        """
+
+        # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
+        # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
+        def param_function(
+            ext: Any,
+            module: Module,
+            g_inp: Tuple[Tensor],
+            g_out: Tuple[Tensor],
+            backproped: Tensor,
+        ) -> Tensor:
+            """Calculate the GGN/Fisher matrix square root with the derivatives object.
+
+            Args:
+                ext: extension that is used
+                module: module that performed forward pass
+                g_inp: input gradient tensors
+                g_out: output gradient tensors
+                backproped: Backpropagated quantities from second-order extension.
+
+            Returns:
+                GGN/Fisher matrix square root.
+            """
+            return getattr(self.derivatives, f"{param_str}_jac_t_mat_prod")(
+                module, g_inp, g_out, backproped, sum_batch=False
+            )
+
+        return param_function

--- a/backpack/extensions/secondorder/sqrt_ggn/base.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/base.py
@@ -29,12 +29,12 @@ class SqrtGGNBaseModule(MatToJacMat):
             derivatives: derivatives object.
             params: List of parameter names. Defaults to None.
         """
-        super().__init__(derivatives, params=params)
-
         if params is not None:
             for param_str in params:
                 if not hasattr(self, param_str):
                     setattr(self, param_str, self._make_param_function(param_str))
+
+        super().__init__(derivatives, params=params)
 
     # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
     # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
@@ -49,7 +49,6 @@ class SqrtGGNBaseModule(MatToJacMat):
         Returns:
             Function that computes the GGN/Fisher matrix square root.
         """
-
         # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
         # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
         def param_function(

--- a/backpack/extensions/secondorder/sqrt_ggn/convnd.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/convnd.py
@@ -1,0 +1,29 @@
+"""Contains extensions for convolution layers used by ``SqrtGGN{Exact, MC}``."""
+from backpack.core.derivatives.conv1d import Conv1DDerivatives
+from backpack.core.derivatives.conv2d import Conv2DDerivatives
+from backpack.core.derivatives.conv3d import Conv3DDerivatives
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
+
+
+class SqrtGGNConv1d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.Conv1d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.Conv1d`` module."""
+        super().__init__(Conv1DDerivatives(), params=["bias", "weight"])
+
+
+class SqrtGGNConv2d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.Conv2d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.Conv2d`` module."""
+        super().__init__(Conv2DDerivatives(), params=["bias", "weight"])
+
+
+class SqrtGGNConv3d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.Conv3d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.Conv3d`` module."""
+        super().__init__(Conv3DDerivatives(), params=["bias", "weight"])

--- a/backpack/extensions/secondorder/sqrt_ggn/convtransposend.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/convtransposend.py
@@ -1,0 +1,29 @@
+"""Contains extensions for convolution layers used by ``SqrtGGN{Exact, MC}``."""
+from backpack.core.derivatives.conv_transpose1d import ConvTranspose1DDerivatives
+from backpack.core.derivatives.conv_transpose2d import ConvTranspose2DDerivatives
+from backpack.core.derivatives.conv_transpose3d import ConvTranspose3DDerivatives
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
+
+
+class SqrtGGNConvTranspose1d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.ConvTranspose1d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.ConvTranspose1d`` module."""
+        super().__init__(ConvTranspose1DDerivatives(), params=["bias", "weight"])
+
+
+class SqrtGGNConvTranspose2d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.ConvTranspose2d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.ConvTranspose2d`` module."""
+        super().__init__(ConvTranspose2DDerivatives(), params=["bias", "weight"])
+
+
+class SqrtGGNConvTranspose3d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.ConvTranspose3d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.ConvTranspose3d`` module."""
+        super().__init__(ConvTranspose3DDerivatives(), params=["bias", "weight"])

--- a/backpack/extensions/secondorder/sqrt_ggn/convtransposend.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/convtransposend.py
@@ -1,4 +1,4 @@
-"""Contains extensions for convolution layers used by ``SqrtGGN{Exact, MC}``."""
+"""Contains transpose convolution layer extensions used by ``SqrtGGN{Exact, MC}``."""
 from backpack.core.derivatives.conv_transpose1d import ConvTranspose1DDerivatives
 from backpack.core.derivatives.conv_transpose2d import ConvTranspose2DDerivatives
 from backpack.core.derivatives.conv_transpose3d import ConvTranspose3DDerivatives

--- a/backpack/extensions/secondorder/sqrt_ggn/dropout.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/dropout.py
@@ -1,6 +1,6 @@
 """Contains extensions for dropout layers used by ``SqrtGGN{Exact, MC}``."""
 from backpack.core.derivatives.dropout import DropoutDerivatives
-from backpack.extensions.secondorder.sqrt_ggn.sqrt_ggn_base import SqrtGGNBaseModule
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
 
 
 class SqrtGGNDropout(SqrtGGNBaseModule):

--- a/backpack/extensions/secondorder/sqrt_ggn/dropout.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/dropout.py
@@ -1,0 +1,11 @@
+"""Contains extensions for dropout layers used by ``SqrtGGN{Exact, MC}``."""
+from backpack.core.derivatives.dropout import DropoutDerivatives
+from backpack.extensions.secondorder.sqrt_ggn.sqrt_ggn_base import SqrtGGNBaseModule
+
+
+class SqrtGGNDropout(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.Dropout`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.Dropout`` module."""
+        super().__init__(DropoutDerivatives())

--- a/backpack/extensions/secondorder/sqrt_ggn/flatten.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/flatten.py
@@ -1,0 +1,47 @@
+"""Contains extensions for the flatten layer used by ``SqrtGGN{Exact, MC}``."""
+from typing import Any, Tuple
+
+from torch import Tensor
+from torch.nn import Module
+
+from backpack.core.derivatives.flatten import FlattenDerivatives
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
+
+
+class SqrtGGNFlatten(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.Tanh`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.Tanh`` module."""
+        super().__init__(FlattenDerivatives())
+
+    # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
+    # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
+    def backpropagate(
+        self,
+        ext: Any,
+        module: Module,
+        grad_inp: Tuple[Tensor],
+        grad_out: Tuple[Tensor],
+        backproped: Tensor,
+    ) -> Tensor:
+        """Backpropagate only if flatten created a node in the computation graph.
+
+        Otherwise, the backward hook will not be called at the right stage and
+        no action must be performed.
+
+        Args:
+            ext: BackPACK extension calling out to the module extension.
+            module: Module that performed the forward pass.
+            grad_inp: Gradients w.r.t. the module inputs.
+            grad_out: Gradients w.r.t. the module outputs.
+            backproped: Backpropagated symmetric factorization of the loss Hessian
+                from the child module.
+
+        Returns:
+            Symmetric loss Hessian factorization, backpropagated through the module.
+        """
+        if self.derivatives.is_no_op(module):
+            return backproped
+        else:
+            return super().backpropagate(ext, module, grad_inp, grad_out, backproped)

--- a/backpack/extensions/secondorder/sqrt_ggn/linear.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/linear.py
@@ -1,0 +1,11 @@
+"""Contains extension for the linear layer used by ``SqrtGGN{Exact, MC}``."""
+from backpack.core.derivatives.linear import LinearDerivatives
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
+
+
+class SqrtGGNLinear(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.Linear`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.Linear`` module."""
+        super().__init__(LinearDerivatives(), params=["bias", "weight"])

--- a/backpack/extensions/secondorder/sqrt_ggn/losses.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/losses.py
@@ -61,16 +61,14 @@ class SqrtGGNBaseLossModule(SqrtGGNBaseModule):
             ValueError: For invalid strategies to represent the loss Hessian.
         """
         loss_hessian_strategy = ext.loss_hessian_strategy
-        subsampling = ext.get_subsampling()
 
         if loss_hessian_strategy == LossHessianStrategy.EXACT:
-            return partial(self.derivatives.sqrt_hessian, subsampling=subsampling)
+            return self.derivatives.sqrt_hessian
         elif loss_hessian_strategy == LossHessianStrategy.SAMPLING:
             mc_samples = ext.get_num_mc_samples()
             return partial(
                 self.derivatives.sqrt_hessian_sampled,
                 mc_samples=mc_samples,
-                subsampling=subsampling,
             )
         else:
             raise ValueError(

--- a/backpack/extensions/secondorder/sqrt_ggn/losses.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/losses.py
@@ -71,9 +71,7 @@ class SqrtGGNBaseLossModule(SqrtGGNBaseModule):
                 mc_samples=mc_samples,
             )
         else:
-            raise ValueError(
-                "Unknown hessian strategy {}".format(loss_hessian_strategy)
-            )
+            raise ValueError(f"Unknown hessian strategy {loss_hessian_strategy}")
 
 
 class SqrtGGNMSELoss(SqrtGGNBaseLossModule):

--- a/backpack/extensions/secondorder/sqrt_ggn/losses.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/losses.py
@@ -39,7 +39,7 @@ class SqrtGGNBaseLossModule(SqrtGGNBaseModule):
             Symmetric factorization of the loss Hessian w.r.t. the module input.
 
         Raises:
-            ValueError: For invalid strategies to represent the loss Hessian.
+            NotImplementedError: For invalid strategies to represent the loss Hessian.
         """
         loss_hessian_strategy = ext.loss_hessian_strategy
 
@@ -51,7 +51,9 @@ class SqrtGGNBaseLossModule(SqrtGGNBaseModule):
                 module, grad_inp, grad_out, mc_samples=mc_samples
             )
         else:
-            raise ValueError(f"Unknown hessian strategy {loss_hessian_strategy}")
+            raise NotImplementedError(
+                f"Unknown hessian strategy {loss_hessian_strategy}"
+            )
 
 
 class SqrtGGNMSELoss(SqrtGGNBaseLossModule):

--- a/backpack/extensions/secondorder/sqrt_ggn/losses.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/losses.py
@@ -1,0 +1,94 @@
+"""Contains base class and extensions for losses used by ``SqrtGGN{Exact, MC}``."""
+from functools import partial
+from typing import Any, Callable, Tuple
+
+from torch import Tensor
+from torch.nn import Module
+
+from backpack.core.derivatives.crossentropyloss import CrossEntropyLossDerivatives
+from backpack.core.derivatives.mseloss import MSELossDerivatives
+from backpack.extensions.secondorder.hbp import LossHessianStrategy
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
+
+
+class SqrtGGNBaseLossModule(SqrtGGNBaseModule):
+    """Base class for losses used by ``SqrtGGN{Exact, MC}``."""
+
+    # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
+    # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
+    def backpropagate(
+        self,
+        ext: Any,
+        module: Module,
+        grad_inp: Tuple[Tensor],
+        grad_out: Tuple[Tensor],
+        backproped: None,
+    ) -> Tensor:
+        """Initialize the backpropagated quantity.
+
+        Uses the exact loss Hessian square root, or a Monte-Carlo approximation
+        thereof.
+
+        Args:
+            ext: BackPACK extension calling out to the module extension.
+            module: Module that performed the forward pass.
+            grad_inp: Gradients w.r.t. the module inputs.
+            grad_out: Gradients w.r.t. the module outputs.
+            backproped: Backpropagated information. Should be ``None``.
+
+        Returns:
+            Symmetric factorization of the loss Hessian w.r.t. the module input.
+        """
+        hess_func = self.make_loss_hessian_func(ext)
+
+        return hess_func(module, grad_inp, grad_out)
+
+    # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
+    # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
+    def make_loss_hessian_func(
+        self, ext: Any
+    ) -> Callable[[Module, Tuple[Tensor], Tuple[Tensor]], Tensor]:
+        """Return a function that evaluates the backpropagated Hessian's representation.
+
+        Args:
+            ext: BackPACK extension that holds the information which representation
+                to generate.
+
+        Returns:
+            Function that evaluates the loss Hessian's symmetric factorization.
+
+        Raises:
+            ValueError: For invalid strategies to represent the loss Hessian.
+        """
+        loss_hessian_strategy = ext.loss_hessian_strategy
+        subsampling = ext.get_subsampling()
+
+        if loss_hessian_strategy == LossHessianStrategy.EXACT:
+            return partial(self.derivatives.sqrt_hessian, subsampling=subsampling)
+        elif loss_hessian_strategy == LossHessianStrategy.SAMPLING:
+            mc_samples = ext.get_num_mc_samples()
+            return partial(
+                self.derivatives.sqrt_hessian_sampled,
+                mc_samples=mc_samples,
+                subsampling=subsampling,
+            )
+        else:
+            raise ValueError(
+                "Unknown hessian strategy {}".format(loss_hessian_strategy)
+            )
+
+
+class SqrtGGNMSELoss(SqrtGGNBaseLossModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.MSELoss`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.MSELoss`` module."""
+        super().__init__(MSELossDerivatives())
+
+
+class SqrtGGNCrossEntropyLoss(SqrtGGNBaseLossModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.CrossEntropyLoss`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.CrossEntropyLoss`` module."""
+        super().__init__(CrossEntropyLossDerivatives())

--- a/backpack/extensions/secondorder/sqrt_ggn/losses.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/losses.py
@@ -41,7 +41,7 @@ class SqrtGGNBaseLossModule(SqrtGGNBaseModule):
         Raises:
             NotImplementedError: For invalid strategies to represent the loss Hessian.
         """
-        loss_hessian_strategy = ext.loss_hessian_strategy
+        loss_hessian_strategy = ext.get_loss_hessian_strategy()
 
         if loss_hessian_strategy == LossHessianStrategy.EXACT:
             return self.derivatives.sqrt_hessian(module, grad_inp, grad_out)

--- a/backpack/extensions/secondorder/sqrt_ggn/padding.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/padding.py
@@ -1,0 +1,11 @@
+"""Contains extensions for padding layers used by ``SqrtGGN{Exact, MC}``."""
+from backpack.core.derivatives.zeropad2d import ZeroPad2dDerivatives
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
+
+
+class SqrtGGNZeroPad2d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.ZeroPad2d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.ZeroPad2d`` module."""
+        super().__init__(ZeroPad2dDerivatives())

--- a/backpack/extensions/secondorder/sqrt_ggn/pooling.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/pooling.py
@@ -1,0 +1,56 @@
+"""Contains extensions for pooling layers used by ``SqrtGGN{Exact, MC}``."""
+from backpack.core.derivatives.avgpool1d import AvgPool1DDerivatives
+from backpack.core.derivatives.avgpool2d import AvgPool2DDerivatives
+from backpack.core.derivatives.avgpool3d import AvgPool3DDerivatives
+from backpack.core.derivatives.maxpool1d import MaxPool1DDerivatives
+from backpack.core.derivatives.maxpool2d import MaxPool2DDerivatives
+from backpack.core.derivatives.maxpool3d import MaxPool3DDerivatives
+from backpack.extensions.secondorder.sqrt_ggn.sqrt_ggn_base import SqrtGGNBaseModule
+
+
+class SqrtGGNMaxPool1d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.MaxPool1d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.MaxPool1d`` module."""
+        super().__init__(MaxPool1DDerivatives())
+
+
+class SqrtGGNMaxPool2d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.MaxPool2d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.MaxPool2d`` module."""
+        super().__init__(MaxPool2DDerivatives())
+
+
+class SqrtGGNMaxPool3d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.MaxPool3d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.MaxPool3d`` module."""
+        super().__init__(MaxPool3DDerivatives())
+
+
+class SqrtGGNAvgPool1d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.AvgPool1d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.AvgPool1d`` module."""
+        super().__init__(AvgPool1DDerivatives())
+
+
+class SqrtGGNAvgPool2d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.AvgPool2d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.AvgPool2d`` module."""
+        super().__init__(AvgPool2DDerivatives())
+
+
+class SqrtGGNAvgPool3d(SqrtGGNBaseModule):
+    """``SqrtGGN{Exact, MC}`` extension for ``torch.nn.AvgPool3d`` module."""
+
+    def __init__(self):
+        """Pass derivatives for ``torch.nn.AvgPool3d`` module."""
+        super().__init__(AvgPool3DDerivatives())

--- a/backpack/extensions/secondorder/sqrt_ggn/pooling.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/pooling.py
@@ -5,7 +5,7 @@ from backpack.core.derivatives.avgpool3d import AvgPool3DDerivatives
 from backpack.core.derivatives.maxpool1d import MaxPool1DDerivatives
 from backpack.core.derivatives.maxpool2d import MaxPool2DDerivatives
 from backpack.core.derivatives.maxpool3d import MaxPool3DDerivatives
-from backpack.extensions.secondorder.sqrt_ggn.sqrt_ggn_base import SqrtGGNBaseModule
+from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
 
 
 class SqrtGGNMaxPool1d(SqrtGGNBaseModule):

--- a/docs_src/examples/basic_usage/example_all_in_one.py
+++ b/docs_src/examples/basic_usage/example_all_in_one.py
@@ -29,6 +29,7 @@ from backpack.extensions import (
     DiagGGNExact,
     DiagGGNMC,
     DiagHessian,
+    SqrtGGNExact,
     SumGradSquared,
     Variance,
 )
@@ -165,6 +166,18 @@ for name, param in model.named_parameters():
     print(".grad.shape:             ", param.grad.shape)
     print(".diag_h.shape:           ", param.diag_h.shape)
     print(".diag_h_batch.shape:     ", param.diag_h_batch.shape)
+
+# %%
+# Matrix square root of the generalized Gauss-Newton
+
+loss = lossfunc(model(X), y)
+with backpack(SqrtGGNExact()):
+    loss.backward()
+
+for name, param in model.named_parameters():
+    print(name)
+    print(".grad.shape:             ", param.grad.shape)
+    print(".sqrt_ggn_exact.shape:   ", param.sqrt_ggn_exact.shape)
 
 # %%
 # Block-diagonal curvature products

--- a/docs_src/rtd/extensions.rst
+++ b/docs_src/rtd/extensions.rst
@@ -25,6 +25,7 @@ Available Extensions
 .. autofunction:: backpack.extensions.KFRA
 .. autofunction:: backpack.extensions.DiagHessian
 .. autofunction:: backpack.extensions.BatchDiagHessian
+.. autofunction:: backpack.extensions.SqrtGGNExact
 
 -----
 

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -14,3 +14,5 @@ backpack/extensions/secondorder/diag_hessian/conv2d.py
 backpack/extensions/secondorder/diag_hessian/conv3d.py
 
 backpack/extensions/__init__.py
+
+backpack/extensions/secondorder/sqrt_ggn

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -4,6 +4,8 @@ test/extensions/secondorder/secondorder_settings.py
 
 test/extensions/secondorder/hbp
 
+test/extensions/secondorder/sqrt_ggn
+
 backpack/extensions/secondorder/__init__.py
 
 backpack/extensions/secondorder/diag_hessian/__init__.py

--- a/makefile
+++ b/makefile
@@ -56,16 +56,16 @@ help:
 ###
 # Test coverage
 test:
-	@pytest -vx --run-optional-tests=montecarlo --cov=backpack .
+	@pytest -vx -rs --run-optional-tests=montecarlo --cov=backpack .
 
 test-light:
-	@pytest -vx --cov=backpack .
+	@pytest -vx -rs --cov=backpack .
 
 test-no-gpu:
-	@pytest -k "not cuda" -vx --run-optional-tests=montecarlo --cov=backpack .
+	@pytest -k "not cuda" -vx -rs --run-optional-tests=montecarlo --cov=backpack .
 
 test-light-no-gpu:
-	@pytest -k "not cuda" -vx --cov=backpack .
+	@pytest -k "not cuda" -vx -rs --cov=backpack .
 
 ###
 # Linter and autoformatter

--- a/test/extensions/implementation/autograd.py
+++ b/test/extensions/implementation/autograd.py
@@ -1,8 +1,9 @@
 from test.extensions.implementation.base import ExtensionsImplementation
 
 import torch
+from torch.nn.utils.convert_parameters import parameters_to_vector
 
-from backpack.hessianfree.ggnvp import ggn_vector_product_from_plist
+from backpack.hessianfree.ggnvp import ggn_vector_product, ggn_vector_product_from_plist
 from backpack.hessianfree.rop import R_op
 from backpack.utils.convert_parameters import vector_to_parameter_list
 
@@ -155,3 +156,24 @@ class AutogradExtensions(ExtensionsImplementation):
         factor = self.problem.get_reduction_factor(batch_loss, loss_list)
         params_batch_diag_h = list(zip(*batch_diag_h))
         return [torch.stack(param) * factor for param in params_batch_diag_h]
+
+    def ggn(self):
+        _, output, loss = self.problem.forward_pass()
+        model = self.problem.model
+
+        num_params = sum(p.numel() for p in model.parameters())
+        ggn = torch.zeros(num_params, num_params).to(self.problem.device)
+
+        for i in range(num_params):
+            # GGN-vector product with i.th unit vector yields the i.th row
+            e_i = torch.zeros(num_params).to(self.problem.device)
+            e_i[i] = 1.0
+
+            # convert to model parameter shapes
+            e_i_list = vector_to_parameter_list(e_i, model.parameters())
+            ggn_i_list = ggn_vector_product(loss, output, model, e_i_list)
+
+            ggn_i = parameters_to_vector(ggn_i_list)
+            ggn[i, :] = ggn_i
+
+        return ggn

--- a/test/extensions/implementation/base.py
+++ b/test/extensions/implementation/base.py
@@ -1,5 +1,4 @@
-"""Base class containing the functions to compare between BackPACK and autograd."""
-
+"""Base class containing the functions to compare BackPACK and autograd."""
 from typing import List
 
 from torch import Tensor

--- a/test/extensions/implementation/base.py
+++ b/test/extensions/implementation/base.py
@@ -1,3 +1,10 @@
+"""Base class containing the functions to compare between BackPACK and autograd."""
+
+from typing import List
+
+from torch import Tensor
+
+
 class ExtensionsImplementation:
     """Base class for autograd and BackPACK implementations of extensions."""
 
@@ -40,36 +47,44 @@ class ExtensionsImplementation:
         """Diagonal of Hessian"""
         raise NotImplementedError
 
-    def kfac(self, mc_samples=1):
+    def kfac(self, mc_samples: int = 1) -> List[List[Tensor]]:
         """Kronecker-factored approximate curvature (KFAC).
 
         Args:
-            mc_samples (int, optional): Number of Monte-Carlo samples. Default: ``1``.
+            mc_samples: Number of Monte-Carlo samples. Default: ``1``.
 
         Returns:
-            list(list(torch.Tensor)): Parameter-wise lists of Kronecker factors.
+            Parameter-wise lists of Kronecker factors.
         """
         raise NotImplementedError
 
-    def kflr(self):
+    def kflr(self) -> List[List[Tensor]]:
         """Kronecker-factored low-rank approximation (KFLR).
 
         Returns:
-            list(list(torch.Tensor)): Parameter-wise lists of Kronecker factors.
+            Parameter-wise lists of Kronecker factors.
         """
         raise NotImplementedError
 
-    def kfra(self):
+    def kfra(self) -> List[List[Tensor]]:
         """Kronecker-factored recursive approximation (KFRA).
 
         Returns:
-            list(list(torch.Tensor)): Parameter-wise lists of Kronecker factors.
+            Parameter-wise lists of Kronecker factors.
         """
 
-    def diag_h_batch(self):
+    def diag_h_batch(self) -> List[Tensor]:
         """Per-sample Hessian diagonal.
 
         Returns:
             list(torch.Tensor): Parameter-wise per-sample Hessian diagonal.
+        """
+        raise NotImplementedError
+
+    def ggn(self) -> Tensor:
+        """Exact generalized Gauss-Newton/Fisher matrix.
+
+        Returns:
+            Matrix representation of the exact GGN.
         """
         raise NotImplementedError

--- a/test/extensions/secondorder/sqrt_ggn/__init__.py
+++ b/test/extensions/secondorder/sqrt_ggn/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests of ``backpack.extensions.secondorder.sqrt_ggn``."""

--- a/test/extensions/secondorder/sqrt_ggn/test_sqrt_ggn.py
+++ b/test/extensions/secondorder/sqrt_ggn/test_sqrt_ggn.py
@@ -30,7 +30,7 @@ def problem(request, max_num_params: int = 4000) -> ExtensionsTestProblem:
     case.set_up()
 
     num_params = sum(p.numel() for p in case.model.parameters() if p.requires_grad)
-    if num_params < max_num_params:
+    if num_params <= max_num_params:
         yield case
     else:
         skip(f"Model has too many parameters: {num_params} > {max_num_params}")

--- a/test/extensions/secondorder/sqrt_ggn/test_sqrt_ggn.py
+++ b/test/extensions/secondorder/sqrt_ggn/test_sqrt_ggn.py
@@ -1,0 +1,50 @@
+"""Tests BackPACK's ``SqrtGGNExact`` extension."""
+
+from test.automated_test import check_sizes_and_values
+from test.extensions.implementation.autograd import AutogradExtensions
+from test.extensions.implementation.backpack import BackpackExtensions
+from test.extensions.problem import ExtensionsTestProblem, make_test_problems
+from test.extensions.secondorder.secondorder_settings import SECONDORDER_SETTINGS
+
+from pytest import fixture, skip
+
+PROBLEMS = make_test_problems(SECONDORDER_SETTINGS)
+IDS = [problem.make_id() for problem in PROBLEMS]
+
+
+@fixture(params=PROBLEMS, ids=IDS)
+def problem(request, max_num_params: int = 4000) -> ExtensionsTestProblem:
+    """Set seed, create tested model, loss, data. Finally clean up.
+
+    Models with too many parameters are skipped.
+
+    Args:
+        request (SubRequest): Request for the fixture from a test/fixture function.
+        max_num_params: Maximum number of model parameters to run the case.
+            Default: ``1000``.
+
+    Yields:
+        Test case with deterministically constructed attributes.
+    """
+    case = request.param
+    case.set_up()
+
+    num_params = sum(p.numel() for p in case.model.parameters() if p.requires_grad)
+    if num_params < max_num_params:
+        yield case
+    else:
+        skip(f"Model has too many parameters: {num_params} > {max_num_params}")
+
+    case.tear_down()
+
+
+def test_sqrt_ggn_exact(problem: ExtensionsTestProblem):
+    """Compare exact GGN from BackPACK's matrix square root with autograd.
+
+    Args:
+        problem: Test case
+    """
+    autograd_res = AutogradExtensions(problem).ggn()
+    backpack_res = BackpackExtensions(problem).ggn()
+
+    check_sizes_and_values(autograd_res, backpack_res)

--- a/test/extensions/secondorder/sqrt_ggn/test_sqrt_ggn.py
+++ b/test/extensions/secondorder/sqrt_ggn/test_sqrt_ggn.py
@@ -21,7 +21,7 @@ def problem(request, max_num_params: int = 4000) -> ExtensionsTestProblem:
     Args:
         request (SubRequest): Request for the fixture from a test/fixture function.
         max_num_params: Maximum number of model parameters to run the case.
-            Default: ``1000``.
+            Default: ``4000``.
 
     Yields:
         Test case with deterministically constructed attributes.


### PR DESCRIPTION
This PR adds an extension that computes the matrix square root of the generalized Gauss-Newton, using an exact factorization of the loss Hessian. For details, see Equation (3) of [this paper](https://arxiv.org/abs/2106.02624v1).

Auxiliary:
- `pytest`: Enable flag to report explanations of skipped tests
- Use `pytest fixtures` to separate the `set_up` and `tear_down` calls from the test (this should also be done for other tests, see https://github.com/fKunstner/backpack-discuss/issues/97) 