### PR TITLE
[TEST] Add setting where `Flatten` does not perform an operation

### DIFF
--- a/test/extensions/secondorder/secondorder_settings.py
+++ b/test/extensions/secondorder/secondorder_settings.py
@@ -233,3 +233,18 @@ GROUP_CONV_SETTINGS = [
 ]
 
 SECONDORDER_SETTINGS += GROUP_CONV_SETTINGS
+
+SECONDORDER_SETTINGS += [
+    {
+        # Flatten layer does not add a node in the computation graph and thus the
+        # backward hook will be called at an unexpected stage. This must explicitly
+        # be addressed in the `backpropagate` function of the flatten module extension.
+        "input_fn": lambda: torch.rand(3, 5),
+        "module_fn": lambda: torch.nn.Sequential(
+            torch.nn.Linear(5, 4), torch.nn.Flatten(), torch.nn.Linear(4, 2)
+        ),
+        "loss_function_fn": lambda: torch.nn.CrossEntropyLoss(reduction="mean"),
+        "target_fn": lambda: classification_targets((3,), 2),
+        "id_prefix": "flatten-no-op",
+    },
+]


### PR DESCRIPTION
Adds an architecture with a `torch.nn.Flatten` layer that does not introduce a node in the computation graph. In this case the backward hook for the `Flatten` module will be called at an unexpected stage, which must be addressed in the second-order extensions.

[This](https://coveralls.io/builds/40739633/source?filename=backpack%2Fextensions%2Fsecondorder%2Fsqrt_ggn%2Fflatten.py#L45) coverage report indicates that the new test suite did not include such a test case, whereas it seems to be covered by the old tests (the coverage report for second-order extensions that are tested in the old suite covers the linked branch in the module extensions for `Flatten`). 