### PR TITLE
[core] Add test of `hessian_is_zero` property

### DIFF
--- a/backpack/core/derivatives/basederivatives.py
+++ b/backpack/core/derivatives/basederivatives.py
@@ -124,11 +124,18 @@ class BaseDerivatives:
         """
         raise NotImplementedError
 
-    def hessian_is_zero(self):
+    def hessian_is_zero(self) -> bool:
+        """Whether ``∂²output[i] / ∂input[j] ∂input[k] = 0  ∀ i,j,k``."""
         raise NotImplementedError
 
-    def hessian_is_diagonal(self):
-        """Is `∂²output[i] / ∂input[j] ∂input[k]` nonzero only if `i = j = k`."""
+    def hessian_is_diagonal(self) -> bool:
+        """Is `∂²output[i] / ∂input[j] ∂input[k]` nonzero only if `i = j = k`.
+
+        The Hessian diagonal is only defined for layers that preserve the size
+        of their input.
+
+        Must be implemented by descendants that don't implement ``hessian_is_zero``.
+        """
         raise NotImplementedError
 
     def hessian_diagonal(self):

--- a/backpack/core/derivatives/basederivatives.py
+++ b/backpack/core/derivatives/basederivatives.py
@@ -1,5 +1,9 @@
 """Base classes for more flexible Jacobians and second-order information."""
 import warnings
+from typing import Tuple
+
+from torch import Tensor
+from torch.nn import Module
 
 from backpack.core.derivatives import shape_check
 
@@ -138,10 +142,22 @@ class BaseDerivatives:
         """
         raise NotImplementedError
 
-    def hessian_diagonal(self):
+    # FIXME Currently returns `∂²output[i] / ∂input[i]² * g_out[0][i]`,
+    # which s the residual matrix diagonal, rather than the Hessian diagonal
+    def hessian_diagonal(
+        self, module: Module, g_in: Tuple[Tensor], g_out: Tuple[Tensor]
+    ) -> Tensor:
         """Return `∂²output[i] / ∂input[i]²`.
 
         Only required if `hessian_is_diagonal` returns `True`.
+
+        Args:
+            module: Module whose output-input Hessian diagonal is computed.
+            g_in: Gradients w.r.t. the module input.
+            g_out: Gradients w.r.t. the module output.
+
+        Returns:
+            Hessian diagonal. Has same shape as module input.
         """
         raise NotImplementedError
 

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -364,15 +364,16 @@ def test_hessian_is_zero(no_loss_problem: DerivativesTestProblem):
         assert backpack_res == autograd_res
 
 
-@pytest.mark.skip
-@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
-def test_hessian_is_diagonal(problem):
-    problem.set_up()
+def test_hessian_is_diagonal(no_loss_problem: DerivativesTestProblem):
+    """Check if the input-output Hessian is diagonal.
 
-    # TODO
-    raise NotImplementedError
+    Args:
+        no_loss_problem: Test case whose module is not a loss.
+    """
+    backpack_res = BackpackDerivatives(no_loss_problem).hessian_is_diagonal()
+    autograd_res = AutogradDerivatives(no_loss_problem).hessian_is_diagonal()
 
-    problem.tear_down()
+    assert backpack_res == autograd_res
 
 
 @pytest.mark.skip

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -362,37 +362,3 @@ def test_hessian_is_zero(no_loss_problem: DerivativesTestProblem):
         )
     else:
         assert backpack_res == autograd_res
-
-
-def test_hessian_is_diagonal(no_loss_problem: DerivativesTestProblem):
-    """Check if the input-output Hessian is diagonal.
-
-    Args:
-        no_loss_problem: Test case whose module is not a loss.
-    """
-    backpack_res = BackpackDerivatives(no_loss_problem).hessian_is_diagonal()
-    autograd_res = AutogradDerivatives(no_loss_problem).hessian_is_diagonal()
-
-    assert backpack_res == autograd_res
-
-
-@pytest.mark.skip
-@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
-def test_hessian_diagonal(problem):
-    problem.set_up()
-
-    # TODO
-    raise NotImplementedError
-
-    problem.tear_down()
-
-
-@pytest.mark.skip
-@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
-def test_hessian_is_psd(problem):
-    problem.set_up()
-
-    # TODO
-    raise NotImplementedError
-
-    problem.tear_down()

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -171,7 +171,7 @@ class AutogradDerivatives(DerivativesImplementation):
             try:
                 yield self.hessian(t, x)
             except (RuntimeError, AttributeError):
-                return torch.zeros(*x.shape, *x.shape, device=x.device, dtype=x.dtype)
+                yield torch.zeros(*x.shape, *x.shape, device=x.device, dtype=x.dtype)
 
     def tensor_hessian(self, tensor, x):
         """Return the Hessian of a tensor `tensor` w.r.t. a tensor `x`.

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -247,3 +247,24 @@ class AutogradDerivatives(DerivativesImplementation):
                     assert torch.allclose(block, hessian_different_samples)
 
         return sum_hessian
+
+    def hessian_is_diagonal(self) -> bool:
+        if self.hessian_is_zero():
+            return True
+
+        input, output, _ = self.problem.forward_pass(input_requires_grad=True)
+        zero = None
+
+        for idx, hessian in enumerate(self.elementwise_hessian(output, input)):
+            hessian = hessian.reshape(input.numel(), input.numel())
+
+            # set diagonal entry to zero
+            hessian[idx, idx] = 0
+
+            if zero is None:
+                zero = torch.zeros_like(hessian)
+
+            if not torch.allclose(hessian, zero):
+                return False
+
+        return True

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -1,7 +1,7 @@
 from test.core.derivatives.implementation.base import DerivativesImplementation
 
 import torch
-from torch import Tensor, zeros_like
+from torch import zeros_like
 
 from backpack.hessianfree.hvp import hessian_vector_product
 from backpack.hessianfree.lop import transposed_jacobian_vector_product

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -160,10 +160,18 @@ class AutogradDerivatives(DerivativesImplementation):
     def elementwise_hessian(self, tensor, x):
         """Yield the Hessian of each element in `tensor` w.r.t `x`.
 
-        Hessians are returned in the order of elements in the flattened tensor.
+        If ``tensor`` is linear in ``x``, autograd raises a ``RuntimeError``.
+        If ``tensor`` does not depend on ``x``, autograd raises an ``AttributeError``.
+        In both cases, a Hessian of zeros is created manually and returned.
+
+        Yields:
+            Hessians in the order of elements in the flattened tensor.
         """
         for t in tensor.flatten():
-            yield self.hessian(t, x)
+            try:
+                yield self.hessian(t, x)
+            except (RuntimeError, AttributeError):
+                return torch.zeros(*x.shape, *x.shape, device=x.device, dtype=x.dtype)
 
     def tensor_hessian(self, tensor, x):
         """Return the Hessian of a tensor `tensor` w.r.t. a tensor `x`.
@@ -185,12 +193,7 @@ class AutogradDerivatives(DerivativesImplementation):
 
         return torch.cat(list(self.elementwise_hessian(tensor, x))).reshape(shape)
 
-    def hessian_is_zero(self):
-        """Return whether the input-output Hessian is zero.
-
-        Returns:
-            bool: `True`, if Hessian is zero, else `False`.
-        """
+    def hessian_is_zero(self) -> bool:
         input, output, _ = self.problem.forward_pass(input_requires_grad=True)
 
         zero = None

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -1,6 +1,7 @@
 from test.core.derivatives.implementation.base import DerivativesImplementation
 
 import torch
+from torch import Tensor, zeros_like
 
 from backpack.hessianfree.hvp import hessian_vector_product
 from backpack.hessianfree.lop import transposed_jacobian_vector_product
@@ -199,7 +200,7 @@ class AutogradDerivatives(DerivativesImplementation):
         zero = None
         for hessian in self.elementwise_hessian(output, input):
             if zero is None:
-                zero = torch.zeros_like(hessian)
+                zero = zeros_like(hessian)
 
             if not torch.allclose(hessian, zero):
                 return False
@@ -247,24 +248,3 @@ class AutogradDerivatives(DerivativesImplementation):
                     assert torch.allclose(block, hessian_different_samples)
 
         return sum_hessian
-
-    def hessian_is_diagonal(self) -> bool:
-        if self.hessian_is_zero():
-            return True
-
-        input, output, _ = self.problem.forward_pass(input_requires_grad=True)
-        zero = None
-
-        for idx, hessian in enumerate(self.elementwise_hessian(output, input)):
-            hessian = hessian.reshape(input.numel(), input.numel())
-
-            # set diagonal entry to zero
-            hessian[idx, idx] = 0
-
-            if zero is None:
-                zero = torch.zeros_like(hessian)
-
-            if not torch.allclose(hessian, zero):
-                return False
-
-        return True

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -81,6 +81,9 @@ class BackpackDerivatives(DerivativesImplementation):
     def hessian_is_zero(self) -> bool:
         return self.problem.derivative.hessian_is_zero()
 
+    def hessian_is_diagonal(self) -> bool:
+        return self.hessian_is_zero() or self.problem.derivative.hessian_is_diagonal()
+
     def _sample_hessians_from_sqrt(self, sqrt):
         """Convert individual matrix square root into individual full matrix."""
         equation = None

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -78,12 +78,7 @@ class BackpackDerivatives(DerivativesImplementation):
             individual_hessians, self.problem.module.input0
         )
 
-    def hessian_is_zero(self):
-        """Return whether the input-output Hessian is zero.
-
-        Returns:
-            bool: `True`, if Hessian is zero, else `False`.
-        """
+    def hessian_is_zero(self) -> bool:
         return self.problem.derivative.hessian_is_zero()
 
     def _sample_hessians_from_sqrt(self, sqrt):

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -1,7 +1,6 @@
 from test.core.derivatives.implementation.base import DerivativesImplementation
 
 import torch
-from torch import Tensor, zeros_like
 
 
 class BackpackDerivatives(DerivativesImplementation):

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -1,6 +1,7 @@
 from test.core.derivatives.implementation.base import DerivativesImplementation
 
 import torch
+from torch import Tensor, zeros_like
 
 
 class BackpackDerivatives(DerivativesImplementation):
@@ -60,7 +61,6 @@ class BackpackDerivatives(DerivativesImplementation):
         return self.problem.derivative.sum_hessian(self.problem.module, None, None)
 
     def input_hessian_via_sqrt_hessian(self, mc_samples=None):
-        # MC_SAMPLES = 100000
         self.store_forward_io()
 
         if mc_samples is not None:
@@ -80,9 +80,6 @@ class BackpackDerivatives(DerivativesImplementation):
 
     def hessian_is_zero(self) -> bool:
         return self.problem.derivative.hessian_is_zero()
-
-    def hessian_is_diagonal(self) -> bool:
-        return self.hessian_is_zero() or self.problem.derivative.hessian_is_diagonal()
 
     def _sample_hessians_from_sqrt(self, sqrt):
         """Convert individual matrix square root into individual full matrix."""

--- a/test/core/derivatives/implementation/base.py
+++ b/test/core/derivatives/implementation/base.py
@@ -26,6 +26,14 @@ class DerivativesImplementation:
         """Return whether the input-output Hessian is zero.
 
         Returns:
-            bool: `True`, if Hessian is zero, else `False`.
+            `True`, if Hessian is zero, else `False`.
+        """
+        raise NotImplementedError
+
+    def hessian_is_diagonal(self) -> bool:
+        """Is `∂²output[i] / ∂input[j] ∂input[k]` nonzero only if `i = j = k`.
+
+        Returns:
+            Whether Hessian is diagonal.
         """
         raise NotImplementedError

--- a/test/core/derivatives/implementation/base.py
+++ b/test/core/derivatives/implementation/base.py
@@ -21,3 +21,11 @@ class DerivativesImplementation:
 
     def bias_jac_mat_prod(self, mat):
         raise NotImplementedError
+
+    def hessian_is_zero(self) -> bool:
+        """Return whether the input-output Hessian is zero.
+
+        Returns:
+            bool: `True`, if Hessian is zero, else `False`.
+        """
+        raise NotImplementedError

--- a/test/core/derivatives/implementation/base.py
+++ b/test/core/derivatives/implementation/base.py
@@ -29,11 +29,3 @@ class DerivativesImplementation:
             `True`, if Hessian is zero, else `False`.
         """
         raise NotImplementedError
-
-    def hessian_is_diagonal(self) -> bool:
-        """Is `∂²output[i] / ∂input[j] ∂input[k]` nonzero only if `i = j = k`.
-
-        Returns:
-            Whether Hessian is diagonal.
-        """
-        raise NotImplementedError


### PR DESCRIPTION
Adds a test that checks `BaseDerivatives.hessian_is_zero` and improves documentation.

It is challenging to test the other properties, as they make additional assumptions about the function represented by a module (e.g. preserves input shape, elementwise function, scalar output). This hints that their interface needs to be improved in the future.


Close https://github.com/fKunstner/backpack-discuss/issues/62