### PR TITLE
[core] Support additional dimensions in input to `Linear`

### DIFF
--- a/backpack/core/derivatives/linear.py
+++ b/backpack/core/derivatives/linear.py
@@ -61,10 +61,24 @@ class LinearDerivatives(BaseParameterDerivatives):
         jac = module.weight.data
         return einsum("ik,ij,jl->kl", (jac, mat, jac))
 
-    def _weight_jac_mat_prod(self, module, g_inp, g_out, mat):
-        """Apply Jacobian of the output w.r.t. the weight."""
-        d_weight = module.input0
-        return einsum("ni,voi->vno", (d_weight, mat))
+    def _weight_jac_mat_prod(
+        self, module: Linear, g_inp: Any, g_out: Any, mat: Tensor
+    ) -> Tensor:
+        """Batch-apply Jacobian of the output w.r.t. the weight.
+
+        Args:
+            module: Linear layer.
+            g_inp: Gradients w.r.t. module input. Not required by the implementation.
+            g_out: Gradients w.r.t. module output. Not required by the implementation.
+            mat: Batch of ``V`` vectors of shape ``module.weight.shape`` to which the
+                transposed output-input Jacobian is applied. Has shape
+                ``[V, *module.weight.shape]``.
+
+        Returns:
+            Batched Jacobian vector products. Has shape
+            ``[V, N, *module.output.shape]``.
+        """
+        return einsum("n...i,voi->vn...o", module.input0, mat)
 
     def _weight_jac_t_mat_prod(
         self, module: Linear, g_inp: Any, g_out: Any, mat: Tensor, sum_batch: int = True

--- a/backpack/core/derivatives/linear.py
+++ b/backpack/core/derivatives/linear.py
@@ -117,13 +117,28 @@ class LinearDerivatives(BaseParameterDerivatives):
         N = module.input0.size(0)
         return mat.unsqueeze(1).expand(-1, N, -1)
 
-    def _bias_jac_t_mat_prod(self, module, g_inp, g_out, mat, sum_batch=True):
-        """Apply transposed Jacobian of the output w.r.t. the bias."""
-        if sum_batch:
-            N_axis = 1
-            return mat.sum(N_axis)
-        else:
-            return mat
+    def _bias_jac_t_mat_prod(
+        self, module: Linear, g_inp: Any, g_out: Any, mat: Tensor, sum_batch: int = True
+    ) -> Tensor:
+        """Batch-apply transposed Jacobian of the output w.r.t. the bias.
+
+        Args:
+            module: Linear layer.
+            g_inp: Gradients w.r.t. module input. Not required by the implementation.
+            g_out: Gradients w.r.t. module output. Not required by the implementation.
+            mat: Batch of ``V`` vectors of same shape as the layer output
+                (``[N, *, out_features]``) to which the transposed output-input Jacobian
+                is applied. Has shape ``[V, N, *, out_features]``.
+            sum_batch: Sum the result's batch axis. Default: ``True``.
+
+        Returns:
+            Batched transposed Jacobian vector products. Has shape
+                ``[V, N, *module.bias.shape]`` when ``sum_batch`` is ``False``. With
+                ``sum_batch=True``, has shape ``[V, *module.bias.shape]``.
+        """
+        equation = f"vn...o->v{'' if sum_batch else 'n'}o"
+
+        return einsum(equation, mat)
 
     @staticmethod
     def _has_additional_dims(module: Linear) -> bool:

--- a/backpack/core/derivatives/linear.py
+++ b/backpack/core/derivatives/linear.py
@@ -1,3 +1,4 @@
+"""Contains partial derivatives for the ``torch.nn.Linear`` layer."""
 from typing import Any
 
 from torch import Size, Tensor, einsum
@@ -17,7 +18,12 @@ class LinearDerivatives(BaseParameterDerivatives):
     * i: Input dimension
     """
 
-    def hessian_is_zero(self):
+    def hessian_is_zero(self) -> bool:
+        """Linear layer output is linear w.r.t. to its input.
+
+        Returns:
+            True
+        """
         return True
 
     def _jac_t_mat_prod(
@@ -72,7 +78,8 @@ class LinearDerivatives(BaseParameterDerivatives):
                 ``[module.output.numel() // N, module.output.numel() // N]``.
 
         Returns:
-           Matrix of shape ``[module.input0.numel() // N, module.input0.numel() // N]``.
+            Matrix of shape
+            ``[module.input0.numel() // N, module.input0.numel() // N]``.
         """
         add_features = self._get_additional_dims(module).numel()
         in_features, out_features = module.in_features, module.out_features

--- a/backpack/core/derivatives/linear.py
+++ b/backpack/core/derivatives/linear.py
@@ -39,10 +39,23 @@ class LinearDerivatives(BaseParameterDerivatives):
         """
         return einsum("oi,vn...o->vn...i", module.weight.data, mat)
 
-    def _jac_mat_prod(self, module, g_inp, g_out, mat):
-        """Apply Jacobian of the output w.r.t. the input."""
-        d_input = module.weight.data
-        return einsum("oi,vni->vno", (d_input, mat))
+    def _jac_mat_prod(
+        self, module: Linear, g_inp: Any, g_out: Any, mat: Tensor
+    ) -> Tensor:
+        """Batch-apply Jacobian of the output w.r.t. the input.
+
+        Args:
+            module: Linear layer.
+            g_inp: Gradients w.r.t. module input. Not required by the implementation.
+            g_out: Gradients w.r.t. module output. Not required by the implementation.
+            mat: Batch of ``V`` vectors of same shape as the layer input
+                (``[N, *, in_features]``) to which the output-input Jacobian is applied.
+                Has shape ``[V, N, *, in_features]``.
+
+        Returns:
+            Batched Jacobian vector products. Has shape ``[V, N, *, out_features]``.
+        """
+        return einsum("oi,vn...i->vn...o", module.weight.data, mat)
 
     def ea_jac_t_mat_jac_prod(self, module, g_inp, g_out, mat):
         jac = module.weight.data

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -18,3 +18,5 @@ backpack/extensions/secondorder/diag_hessian/conv3d.py
 backpack/extensions/__init__.py
 
 backpack/extensions/secondorder/sqrt_ggn
+
+backpack/core/derivatives/linear.py

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -10,7 +10,6 @@
 from test.automated_test import check_sizes_and_values
 from test.core.derivatives.implementation.autograd import AutogradDerivatives
 from test.core.derivatives.implementation.backpack import BackpackDerivatives
-from test.core.derivatives.linear_settings import LINEAR_ADDITIONAL_DIMS_SETTINGS
 from test.core.derivatives.loss_settings import LOSS_FAIL_SETTINGS
 from test.core.derivatives.problem import DerivativesTestProblem, make_test_problems
 from test.core.derivatives.settings import SETTINGS
@@ -33,18 +32,8 @@ LOSS_IDS = [problem.make_id() for problem in LOSS_PROBLEMS]
 LOSS_FAIL_PROBLEMS = make_test_problems(LOSS_FAIL_SETTINGS)
 LOSS_FAIL_IDS = [problem.make_id() for problem in LOSS_FAIL_PROBLEMS]
 
-# linear layer with additional dimensions
-LINEAR_ADDITIONAL_DIMS_PROBLEMS = make_test_problems(LINEAR_ADDITIONAL_DIMS_SETTINGS)
-LINEAR_ADDITIONAL_DIMS_IDS = [
-    problem.make_id() for problem in LINEAR_ADDITIONAL_DIMS_PROBLEMS
-]
 
-
-@pytest.mark.parametrize(
-    "problem",
-    NO_LOSS_PROBLEMS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
-    ids=NO_LOSS_IDS + LINEAR_ADDITIONAL_DIMS_IDS,
-)
+@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
 def test_jac_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
     """Test the Jacobian-matrix product.
 
@@ -62,11 +51,7 @@ def test_jac_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
     problem.tear_down()
 
 
-@pytest.mark.parametrize(
-    "problem",
-    NO_LOSS_PROBLEMS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
-    ids=NO_LOSS_IDS + LINEAR_ADDITIONAL_DIMS_IDS,
-)
+@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
 def test_jac_t_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
     """Test the transposed Jacobian-matrix product.
 
@@ -100,11 +85,7 @@ for problem, problem_id in zip(PROBLEMS, IDS):
     [True, False],
     ids=["save_memory=True", "save_memory=False"],
 )
-@pytest.mark.parametrize(
-    "problem",
-    PROBLEMS_WITH_WEIGHTS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
-    ids=IDS_WITH_WEIGHTS + LINEAR_ADDITIONAL_DIMS_IDS,
-)
+@pytest.mark.parametrize("problem", PROBLEMS_WITH_WEIGHTS, ids=IDS_WITH_WEIGHTS)
 def test_weight_jac_t_mat_prod(
     problem: DerivativesTestProblem, sum_batch: bool, save_memory: bool, V: int = 3
 ) -> None:
@@ -129,11 +110,7 @@ def test_weight_jac_t_mat_prod(
     problem.tear_down()
 
 
-@pytest.mark.parametrize(
-    "problem",
-    PROBLEMS_WITH_WEIGHTS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
-    ids=IDS_WITH_WEIGHTS + LINEAR_ADDITIONAL_DIMS_IDS,
-)
+@pytest.mark.parametrize("problem", PROBLEMS_WITH_WEIGHTS, ids=IDS_WITH_WEIGHTS)
 def test_weight_jac_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
     """Test the Jacobian-matrix product w.r.t. to the weight.
 
@@ -162,11 +139,7 @@ for problem, problem_id in zip(PROBLEMS, IDS):
 @pytest.mark.parametrize(
     "sum_batch", [True, False], ids=["sum_batch=True", "sum_batch=False"]
 )
-@pytest.mark.parametrize(
-    "problem",
-    PROBLEMS_WITH_BIAS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
-    ids=IDS_WITH_BIAS + LINEAR_ADDITIONAL_DIMS_IDS,
-)
+@pytest.mark.parametrize("problem", PROBLEMS_WITH_BIAS, ids=IDS_WITH_BIAS)
 def test_bias_jac_t_mat_prod(
     problem: DerivativesTestProblem, sum_batch: bool, V: int = 3
 ) -> None:
@@ -187,11 +160,7 @@ def test_bias_jac_t_mat_prod(
     problem.tear_down()
 
 
-@pytest.mark.parametrize(
-    "problem",
-    PROBLEMS_WITH_BIAS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
-    ids=IDS_WITH_BIAS + LINEAR_ADDITIONAL_DIMS_IDS,
-)
+@pytest.mark.parametrize("problem", PROBLEMS_WITH_BIAS, ids=IDS_WITH_BIAS)
 def test_bias_jac_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
     """Test the Jacobian-matrix product w.r.t. to the bias.
 
@@ -285,11 +254,7 @@ def test_sum_hessian_should_fail(problem):
         test_sum_hessian(problem)
 
 
-@pytest.mark.parametrize(
-    "problem",
-    NO_LOSS_PROBLEMS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
-    ids=NO_LOSS_IDS + LINEAR_ADDITIONAL_DIMS_IDS,
-)
+@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
 def test_ea_jac_t_mat_jac_prod(problem: DerivativesTestProblem) -> None:
     """Test KFRA backpropagation.
 

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -40,13 +40,17 @@ LINEAR_ADDITIONAL_DIMS_IDS = [
 ]
 
 
-@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
-def test_jac_mat_prod(problem, V=3):
+@pytest.mark.parametrize(
+    "problem",
+    NO_LOSS_PROBLEMS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
+    ids=NO_LOSS_IDS + LINEAR_ADDITIONAL_DIMS_IDS,
+)
+def test_jac_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
     """Test the Jacobian-matrix product.
 
     Args:
-        problem (DerivativesProblem): Problem for derivative test.
-        V (int): Number of vectorized Jacobian-vector products.
+        problem: Test case.
+        V (int): Number of vectorized Jacobian-vector products. Default: ``3``.
     """
     problem.set_up()
     mat = torch.rand(V, *problem.input_shape).to(problem.device)

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -100,15 +100,21 @@ for problem, problem_id in zip(PROBLEMS, IDS):
     [True, False],
     ids=["save_memory=True", "save_memory=False"],
 )
-@pytest.mark.parametrize("problem", PROBLEMS_WITH_WEIGHTS, ids=IDS_WITH_WEIGHTS)
-def test_weight_jac_t_mat_prod(problem, sum_batch, save_memory, V=3):
-    """Test the transposed Jacobian-matrix product w.r.t. to the weights.
+@pytest.mark.parametrize(
+    "problem",
+    PROBLEMS_WITH_WEIGHTS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
+    ids=IDS_WITH_WEIGHTS + LINEAR_ADDITIONAL_DIMS_IDS,
+)
+def test_weight_jac_t_mat_prod(
+    problem: DerivativesTestProblem, sum_batch: bool, save_memory: bool, V: int = 3
+) -> None:
+    """Test the transposed Jacobian-matrix product w.r.t. to the weight.
 
     Args:
-        problem (DerivativesProblem): Problem for derivative test.
-        sum_batch (bool): Sum results over the batch dimension.
-        save_memory (bool): Use Owkin implementation to save memory.
-        V (int): Number of vectorized transposed Jacobian-vector products.
+        problem: Test case.
+        sum_batch: Sum out the batch dimension.
+        save_memory: Use Owkin implementation in convolutions to save memory.
+        V: Number of vectorized transposed Jacobian-vector products. Default: ``3``.
     """
     problem.set_up()
     mat = torch.rand(V, *problem.output_shape).to(problem.device)

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -129,13 +129,17 @@ def test_weight_jac_t_mat_prod(
     problem.tear_down()
 
 
-@pytest.mark.parametrize("problem", PROBLEMS_WITH_WEIGHTS, ids=IDS_WITH_WEIGHTS)
-def test_weight_jac_mat_prod(problem, V=3):
-    """Test the Jacobian-matrix product w.r.t. to the weights.
+@pytest.mark.parametrize(
+    "problem",
+    PROBLEMS_WITH_WEIGHTS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
+    ids=IDS_WITH_WEIGHTS + LINEAR_ADDITIONAL_DIMS_IDS,
+)
+def test_weight_jac_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
+    """Test the Jacobian-matrix product w.r.t. to the weight.
 
     Args:
-        problem (DerivativesProblem): Problem for derivative test.
-        V (int): Number of vectorized transposed Jacobian-vector products.
+        problem: Test case.
+        V: Number of vectorized Jacobian-vector products. Default: ``3``.
     """
     problem.set_up()
     mat = torch.rand(V, *problem.module.weight.shape).to(problem.device)

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -285,9 +285,13 @@ def test_sum_hessian_should_fail(problem):
         test_sum_hessian(problem)
 
 
-@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
-def test_ea_jac_t_mat_jac_prod(problem):
-    """Test KFRA backpropagation
+@pytest.mark.parametrize(
+    "problem",
+    NO_LOSS_PROBLEMS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
+    ids=NO_LOSS_IDS + LINEAR_ADDITIONAL_DIMS_IDS,
+)
+def test_ea_jac_t_mat_jac_prod(problem: DerivativesTestProblem) -> None:
+    """Test KFRA backpropagation.
 
     H_in →  1/N ∑ₙ Jₙ^T H_out Jₙ
 
@@ -298,10 +302,10 @@ def test_ea_jac_t_mat_jac_prod(problem):
         as `Dropout` is not deterministic.
 
     Args:
-        problem (DerivativesProblem): Problem for derivative test.
+        problem: Test case.
     """
     problem.set_up()
-    out_features = torch.prod(torch.tensor(problem.output_shape[1:]))
+    out_features = problem.output_shape[1:].numel()
     mat = torch.rand(out_features, out_features).to(problem.device)
 
     backpack_res = BackpackDerivatives(problem).ea_jac_t_mat_jac_prod(mat)

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -189,15 +189,15 @@ def test_bias_jac_t_mat_prod(
 
 @pytest.mark.parametrize(
     "problem",
-    PROBLEMS_WITH_BIAS,
-    ids=IDS_WITH_BIAS,
+    PROBLEMS_WITH_BIAS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
+    ids=IDS_WITH_BIAS + LINEAR_ADDITIONAL_DIMS_IDS,
 )
-def test_bias_jac_mat_prod(problem, V=3):
-    """Test the Jacobian-matrix product w.r.t. to the biass.
+def test_bias_jac_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
+    """Test the Jacobian-matrix product w.r.t. to the bias.
 
     Args:
-        problem (DerivativesProblem): Problem for derivative test.
-        V (int): Number of vectorized transposed Jacobian-vector products.
+        problem: Test case.
+        V: Number of vectorized Jacobian-vector products. Default: ``3``.
     """
     problem.set_up()
     mat = torch.rand(V, *problem.module.bias.shape).to(problem.device)

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -164,16 +164,18 @@ for problem, problem_id in zip(PROBLEMS, IDS):
 )
 @pytest.mark.parametrize(
     "problem",
-    PROBLEMS_WITH_BIAS,
-    ids=IDS_WITH_BIAS,
+    PROBLEMS_WITH_BIAS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
+    ids=IDS_WITH_BIAS + LINEAR_ADDITIONAL_DIMS_IDS,
 )
-def test_bias_jac_t_mat_prod(problem, sum_batch, V=3):
-    """Test the transposed Jacobian-matrix product w.r.t. to the biass.
+def test_bias_jac_t_mat_prod(
+    problem: DerivativesTestProblem, sum_batch: bool, V: int = 3
+) -> None:
+    """Test the transposed Jacobian-matrix product w.r.t. to the bias.
 
     Args:
-        problem (DerivativesProblem): Problem for derivative test.
-        sum_batch (bool): Sum results over the batch dimension.
-        V (int): Number of vectorized transposed Jacobian-vector products.
+        problem: Test case.
+        sum_batch: Sum out the batch dimension.
+        V: Number of vectorized transposed Jacobian-vector products. Default: ``3``.
     """
     problem.set_up()
     mat = torch.rand(V, *problem.output_shape).to(problem.device)

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -10,8 +10,9 @@
 from test.automated_test import check_sizes_and_values
 from test.core.derivatives.implementation.autograd import AutogradDerivatives
 from test.core.derivatives.implementation.backpack import BackpackDerivatives
+from test.core.derivatives.linear_settings import LINEAR_ADDITIONAL_DIMS_SETTINGS
 from test.core.derivatives.loss_settings import LOSS_FAIL_SETTINGS
-from test.core.derivatives.problem import make_test_problems
+from test.core.derivatives.problem import DerivativesTestProblem, make_test_problems
 from test.core.derivatives.settings import SETTINGS
 
 import pytest
@@ -32,6 +33,12 @@ LOSS_IDS = [problem.make_id() for problem in LOSS_PROBLEMS]
 LOSS_FAIL_PROBLEMS = make_test_problems(LOSS_FAIL_SETTINGS)
 LOSS_FAIL_IDS = [problem.make_id() for problem in LOSS_FAIL_PROBLEMS]
 
+# linear layer with additional dimensions
+LINEAR_ADDITIONAL_DIMS_PROBLEMS = make_test_problems(LINEAR_ADDITIONAL_DIMS_SETTINGS)
+LINEAR_ADDITIONAL_DIMS_IDS = [
+    problem.make_id() for problem in LINEAR_ADDITIONAL_DIMS_PROBLEMS
+]
+
 
 @pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
 def test_jac_mat_prod(problem, V=3):
@@ -51,13 +58,17 @@ def test_jac_mat_prod(problem, V=3):
     problem.tear_down()
 
 
-@pytest.mark.parametrize("problem", NO_LOSS_PROBLEMS, ids=NO_LOSS_IDS)
-def test_jac_t_mat_prod(problem, V=3):
+@pytest.mark.parametrize(
+    "problem",
+    NO_LOSS_PROBLEMS + LINEAR_ADDITIONAL_DIMS_PROBLEMS,
+    ids=NO_LOSS_IDS + LINEAR_ADDITIONAL_DIMS_IDS,
+)
+def test_jac_t_mat_prod(problem: DerivativesTestProblem, V: int = 3) -> None:
     """Test the transposed Jacobian-matrix product.
 
     Args:
-        problem (DerivativesProblem): Problem for derivative test.
-        V (int): Number of vectorized transposed Jacobian-vector products.
+        problem: Test case.
+        V: Number of vectorized transposed Jacobian-vector products. Default: ``3``.
     """
     problem.set_up()
     mat = torch.rand(V, *problem.output_shape).to(problem.device)

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -49,8 +49,8 @@ class AutogradDerivatives(DerivativesImplementation):
         else:
             N = input.shape[0]
 
-            sample_outputs = [output[n] for n in range(N)]
-            sample_vecs = [vec[n] for n in range(N)]
+            sample_outputs = [output[[n]] for n in range(N)]
+            sample_vecs = [vec[[n]] for n in range(N)]
 
             jac_t_sample_prods = [
                 transposed_jacobian_vector_product(n_out, param, n_vec)[0]

--- a/test/core/derivatives/linear_settings.py
+++ b/test/core/derivatives/linear_settings.py
@@ -6,7 +6,7 @@ Required entries:
     "input_fn" (callable): Used for specifying input function
 
 Optional entries:
-    "target_fn" (callable): Fetches the groundtruth/target classes 
+    "target_fn" (callable): Fetches the groundtruth/target classes
                             of regression/classification task
     "loss_function_fn" (callable): Loss function used in the model
     "device" [list(torch.device)]: List of devices to run the test on.
@@ -53,5 +53,23 @@ LINEAR_SETTINGS += [
         "input_fn": lambda: torch.Tensor(
             [(-1, 43, 1.3), (-2, -0.3, 2.3), (0, -4, 0.33)]
         ),
+    },
+]
+
+LINEAR_ADDITIONAL_DIMS_SETTINGS = [
+    {
+        "module_fn": lambda: torch.nn.Linear(in_features=4, out_features=3, bias=True),
+        "input_fn": lambda: torch.rand(size=(3, 2, 4)),
+        "id_prefix": "one-additional",
+    },
+    {
+        "module_fn": lambda: torch.nn.Linear(in_features=4, out_features=3, bias=True),
+        "input_fn": lambda: torch.rand(size=(3, 2, 3, 4)),
+        "id_prefix": "two-additional",
+    },
+    {
+        "module_fn": lambda: torch.nn.Linear(in_features=4, out_features=3, bias=True),
+        "input_fn": lambda: torch.rand(size=(3, 2, 3, 5, 4)),
+        "id_prefix": "three-additional",
     },
 ]

--- a/test/core/derivatives/linear_settings.py
+++ b/test/core/derivatives/linear_settings.py
@@ -56,7 +56,8 @@ LINEAR_SETTINGS += [
     },
 ]
 
-LINEAR_ADDITIONAL_DIMS_SETTINGS = [
+# additional dimensions
+LINEAR_SETTINGS += [
     {
         "module_fn": lambda: torch.nn.Linear(in_features=4, out_features=3, bias=True),
         "input_fn": lambda: torch.rand(size=(3, 2, 4)),


### PR DESCRIPTION
The [derivatives of `nn.Linear`](https://github.com/f-dangel/backpack/blob/development/backpack/core/derivatives/linear.py) assume the layer input to have shape `[batch_size, in_features]`, and the output to have shape `[batch_size, out_features]`. However, in general inputs of shape `[batch_size, *, in_features]` with an arbitrary number of free axes `*` are allowed, see [the doc](https://pytorch.org/docs/stable/generated/torch.nn.Linear.html).

This PR adds support for additional axes to the `LinearDerivatives` in the `core`. Support for extensions will be provided through a separate PR.

Resolves the first part of https://github.com/fKunstner/backpack-discuss/issues/99.