### PR TITLE
[REQ] Fully deprecate python3.6

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -1,7 +1,7 @@
 # <img alt="BackPACK" src="./logo/backpack_logo_torch.svg" height="90"> BackPACK developer manual
 
-## General standards 
-- Python version: support 3.6+, use 3.7 for development
+## General standards
+- Python version: support 3.7+, use 3.7 for development
 - `git` [branching model](https://nvie.com/posts/a-successful-git-branching-model/)
 - Docstring style:  [Google](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
 - Test runner: [`pytest`](https://docs.pytest.org/en/latest/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis](https://travis-ci.org/f-dangel/backpack.svg?branch=master)](https://travis-ci.org/f-dangel/backpack)
 [![Coveralls](https://coveralls.io/repos/github/f-dangel/backpack/badge.svg?branch=master)](https://coveralls.io/github/f-dangel/backpack)
-[![Python 3.6+](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![Python 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/release/python-370/)
 
 BackPACK is built on top of [PyTorch](https://github.com/pytorch/pytorch). It efficiently computes quantities other than the gradient.
 

--- a/backpack/extensions/secondorder/sqrt_ggn/base.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/base.py
@@ -1,11 +1,16 @@
 """Contains base class for ``SqrtGGN{Exact, MC}`` module extensions."""
-from typing import Any, Callable, List, Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, List, Tuple, Union
 
 from torch import Tensor
 from torch.nn import Module
 
 from backpack.core.derivatives.basederivatives import BaseDerivatives
 from backpack.extensions.mat_to_mat_jac_base import MatToJacMat
+
+if TYPE_CHECKING:
+    from backpack.extensions.secondorder.sqrt_ggn import SqrtGGNExact, SqrtGGNMC
 
 
 class SqrtGGNBaseModule(MatToJacMat):
@@ -28,11 +33,12 @@ class SqrtGGNBaseModule(MatToJacMat):
 
         super().__init__(derivatives, params=params)
 
-    # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
-    # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
     def _make_param_function(
         self, param_str: str
-    ) -> Callable[[Any, Module, Tuple[Tensor], Tuple[Tensor], Tensor], Tensor]:
+    ) -> Callable[
+        [Union[SqrtGGNExact, SqrtGGNMC], Module, Tuple[Tensor], Tuple[Tensor], Tensor],
+        Tensor,
+    ]:
         """Create a function that computes the GGN/Fisher square root for a parameter.
 
         Args:
@@ -41,10 +47,9 @@ class SqrtGGNBaseModule(MatToJacMat):
         Returns:
             Function that computes the GGN/Fisher matrix square root.
         """
-        # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
-        # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
+
         def param_function(
-            ext: Any,
+            ext: Union[SqrtGGNExact, SqrtGGNMC],
             module: Module,
             g_inp: Tuple[Tensor],
             g_out: Tuple[Tensor],

--- a/backpack/extensions/secondorder/sqrt_ggn/flatten.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/flatten.py
@@ -1,11 +1,16 @@
 """Contains extensions for the flatten layer used by ``SqrtGGN{Exact, MC}``."""
-from typing import Any, Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple, Union
 
 from torch import Tensor
 from torch.nn import Module
 
 from backpack.core.derivatives.flatten import FlattenDerivatives
 from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
+
+if TYPE_CHECKING:
+    from backpack.extensions.secondorder.sqrt_ggn import SqrtGGNExact, SqrtGGNMC
 
 
 class SqrtGGNFlatten(SqrtGGNBaseModule):
@@ -15,11 +20,9 @@ class SqrtGGNFlatten(SqrtGGNBaseModule):
         """Pass derivatives for ``torch.nn.Flatten`` module."""
         super().__init__(FlattenDerivatives())
 
-    # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
-    # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
     def backpropagate(
         self,
-        ext: Any,
+        ext: Union[SqrtGGNExact, SqrtGGNMC],
         module: Module,
         grad_inp: Tuple[Tensor],
         grad_out: Tuple[Tensor],

--- a/backpack/extensions/secondorder/sqrt_ggn/losses.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/losses.py
@@ -1,5 +1,7 @@
 """Contains base class and extensions for losses used by ``SqrtGGN{Exact, MC}``."""
-from typing import Any, Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple, Union
 
 from torch import Tensor
 from torch.nn import Module
@@ -9,15 +11,16 @@ from backpack.core.derivatives.mseloss import MSELossDerivatives
 from backpack.extensions.secondorder.hbp import LossHessianStrategy
 from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
 
+if TYPE_CHECKING:
+    from backpack.extensions.secondorder.sqrt_ggn import SqrtGGNExact, SqrtGGNMC
+
 
 class SqrtGGNBaseLossModule(SqrtGGNBaseModule):
     """Base class for losses used by ``SqrtGGN{Exact, MC}``."""
 
-    # TODO Replace Any with Union[SqrtGGNExact, SqrtGGNMC]
-    # WAITING Deprecation of python3.6 (cyclic imports caused by annotations)
     def backpropagate(
         self,
-        ext: Any,
+        ext: Union[SqrtGGNExact, SqrtGGNMC],
         module: Module,
         grad_inp: Tuple[Tensor],
         grad_out: Tuple[Tensor],

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -39,7 +38,7 @@ install_requires =
     torchvision >= 0.7.0, < 1.0.0
     einops >= 0.3.0, < 1.0.0
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 exclude = test*

--- a/test/test___init__.py
+++ b/test/test___init__.py
@@ -1,5 +1,6 @@
 """Tests for `backpack.__init__.py`."""
 
+from contextlib import nullcontext
 from test import pytorch_current_memory_usage
 from test.core.derivatives.utils import classification_targets, get_available_devices
 
@@ -10,21 +11,6 @@ from backpack import disable, extend
 
 DEVICES = get_available_devices()
 DEVICES_ID = [str(dev) for dev in DEVICES]
-
-
-# TODO Use contextlib.nullcontext after dropping Python 3.6 support
-class nullcontext:
-    """Empty context.
-
-    ``contextlib.nullcontext`` is available from Python 3.7 onwards.
-    The tests are also executed on Python 3.6.
-    """
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, type, value, traceback):
-        pass
 
 
 def test_no_io():


### PR DESCRIPTION
* Type annotations with cyclic imports, supported in `python3.7+`
* Update documentation and python requirement