### PR TITLE
[core] Support sub-sampling in loss Hessian factorization

### DIFF
--- a/backpack/core/derivatives/basederivatives.py
+++ b/backpack/core/derivatives/basederivatives.py
@@ -687,7 +687,6 @@ class BaseLossDerivatives(BaseDerivatives, ABC):
         g_out: Tuple[Tensor],
         subsampling: List[int] = None,
     ) -> Tensor:
-        """Internal implementation of the loss Hessian's symmetric factorization."""
         raise NotImplementedError
 
     # TODO Add shape check
@@ -734,7 +733,6 @@ class BaseLossDerivatives(BaseDerivatives, ABC):
         mc_samples: int = 1,
         subsampling=None,
     ) -> Tensor:
-        """Internal implementation of symmetric Hessian factorization via MC."""
         raise NotImplementedError
 
     @shape_check.make_hessian_mat_prod_accept_vectors

--- a/backpack/core/derivatives/basederivatives.py
+++ b/backpack/core/derivatives/basederivatives.py
@@ -651,24 +651,43 @@ class BaseLossDerivatives(BaseDerivatives, ABC):
 
     # TODO Add shape check
     def sqrt_hessian(
-        self, module: Module, g_inp: Tuple[Tensor], g_out: Tuple[Tensor]
+        self,
+        module: Module,
+        g_inp: Tuple[Tensor],
+        g_out: Tuple[Tensor],
+        subsampling: List[int] = None,
     ) -> Tensor:
         """Symmetric factorization ('sqrt') of the loss Hessian.
 
+        The Hessian factorization is returned in format ``Hs = [D, N, D]``, where
+        ``Hs[:, n, :]`` is the Hessian factorization for the ``n``th sample, i.e.
+        ``Hs[:, n, :]ᵀ Hs[:, n, :]`` is the Hessian w.r.t. to the ``n``th sample.
+
         Args:
-            module: module to perform derivatives on
-            g_inp: input gradients
-            g_out: output gradients
+            module: Loss layer whose factorized Hessian will be computed.
+            g_inp: Gradients w.r.t. module input.
+            g_out: Gradients w.r.t. module output.
+            subsampling: Indices of data samples to be considered. Default of ``None``
+                uses all data in the mini-batch.
 
         Returns:
-            square root of hessian
+            Symmetric factorization of the loss Hessian for each sample. If the input
+            to the loss has shape ``[N, D]``, this is a tensor of shape ``[D, N, D]``;
+            if used with sub-sampling, ``N`` is replaced by ``len(subsampling)``.
+            For fixed ``n``, squaring the matrix implied by the slice ``[:, n, :]``
+            results in the loss Hessian w.r.t. to sample ``n``.
         """
         self._check_2nd_order_make_sense(module, g_out)
-        return self._sqrt_hessian(module, g_inp, g_out)
+        return self._sqrt_hessian(module, g_inp, g_out, subsampling=subsampling)
 
     def _sqrt_hessian(
-        self, module: Module, g_inp: Tuple[Tensor], g_out: Tuple[Tensor]
+        self,
+        module: Module,
+        g_inp: Tuple[Tensor],
+        g_out: Tuple[Tensor],
+        subsampling: List[int] = None,
     ) -> Tensor:
+        """Internal implementation of the loss Hessian's symmetric factorization."""
         raise NotImplementedError
 
     # TODO Add shape check
@@ -678,20 +697,34 @@ class BaseLossDerivatives(BaseDerivatives, ABC):
         g_inp: Tuple[Tensor],
         g_out: Tuple[Tensor],
         mc_samples: int = 1,
+        subsampling: List[int] = None,
     ) -> Tensor:
-        """Monte-Carlo sampled symmetric factorization of the loss Hessian.
+        """A Monte-Carlo sampled symmetric factorization of the loss Hessian.
+
+        The Hessian factorization is returned in format ``Hs = [M, N, D]``, where
+        ``Hs[:, n, :]`` approximates the Hessian factorization for the ``n``th sample,
+        i.e. ``Hs[:, n, :]ᵀ Hs[:, n, :]ᵀ`` approximates the Hessian w.r.t. to sample
+        ``n``.
 
         Args:
-            module: module to perform derivatives on
-            g_inp: input gradients
-            g_out: output gradients
-            mc_samples: number of monte carlo samples. Defaults to 1.
+            module: Loss layer whose factorized Hessian will be computed.
+            g_inp: Gradients w.r.t. module input.
+            g_out: Gradients w.r.t. module output.
+            mc_samples: Number of samples used for MC approximation.
+            subsampling: Indices of data samples to be considered. Default of ``None``
+                uses all data in the mini-batch.
 
         Returns:
-            square root of hessian
+            Symmetric factorization of the loss Hessian for each sample. If the input
+            to the loss has shape ``[N, D]``, this is a tensor of shape ``[M, N, D]``
+            when using ``M`` MC samples; if used with sub-sampling, ``N`` is replaced
+            by ``len(subsampling)``. For fixed ``n``, squaring the matrix implied by the
+            slice ``[:, n, :]`` approximates the loss Hessian w.r.t. to sample ``n``.
         """
         self._check_2nd_order_make_sense(module, g_out)
-        return self._sqrt_hessian_sampled(module, g_inp, g_out, mc_samples=mc_samples)
+        return self._sqrt_hessian_sampled(
+            module, g_inp, g_out, mc_samples=mc_samples, subsampling=subsampling
+        )
 
     def _sqrt_hessian_sampled(
         self,
@@ -699,7 +732,9 @@ class BaseLossDerivatives(BaseDerivatives, ABC):
         g_inp: Tuple[Tensor],
         g_out: Tuple[Tensor],
         mc_samples: int = 1,
+        subsampling=None,
     ) -> Tensor:
+        """Internal implementation of symmetric Hessian factorization via MC."""
         raise NotImplementedError
 
     @shape_check.make_hessian_mat_prod_accept_vectors

--- a/backpack/core/derivatives/mseloss.py
+++ b/backpack/core/derivatives/mseloss.py
@@ -1,8 +1,10 @@
 """Derivatives of the MSE Loss."""
 
 from math import sqrt
+from typing import List, Tuple
 
-from torch import einsum, eye, normal
+from torch import Tensor, eye, normal
+from torch.nn import MSELoss
 
 from backpack.core.derivatives.basederivatives import BaseLossDerivatives
 
@@ -16,46 +18,43 @@ class MSELossDerivatives(BaseLossDerivatives):
     `∑ᵢ₌₁ⁿ ‖X[i,∶] − Y[i,∶]‖²`. If `reduce=mean`, the result is divided by `nd`.
     """
 
-    def _sqrt_hessian(self, module, g_inp, g_out):
-        """Square-root of the hessian of the MSE for each minibatch elements.
-
-        Returns the Hessian in format `Hs = [D, N, D]`, where
-        `Hs[:, n, :]` is the Hessian for the `n`th element.
-
-        Attributes:
-            module: (torch.nn.MSELoss) module
-            g_inp: Gradient of loss w.r.t. input
-            g_out: Gradient of loss w.r.t. output
-
-        Returns:
-             Batch of hessians, in format [D, N, D]
-        """
+    def _sqrt_hessian(
+        self,
+        module: MSELoss,
+        g_inp: Tuple[Tensor],
+        g_out: Tuple[Tensor],
+        subsampling: List[int] = None,
+    ) -> Tensor:  # noqa: D102
         self.check_input_dims(module)
 
         N, D = module.input0.shape
-        sqrt_H = sqrt(2) * eye(D, device=module.input0.device)  # [D, D]
-        sqrt_H = sqrt_H.unsqueeze(0).repeat(N, 1, 1)  # [N, D, D]
-        sqrt_H = einsum("nab->anb", sqrt_H)  # [D, N, D]
+        N_active = N if subsampling is None else len(subsampling)
+        sqrt_H = (
+            (sqrt(2) * eye(D, device=module.input0.device))
+            .unsqueeze(1)
+            .repeat(1, N_active, 1)
+        )
 
         if module.reduction == "mean":
             sqrt_H /= sqrt(module.input0.numel())
 
         return sqrt_H
 
-    def _sqrt_hessian_sampled(self, module, g_inp, g_out, mc_samples=1):
-        """A Monte-Carlo estimate of the square-root of the Hessian.
+    def _sqrt_hessian_sampled(
+        self,
+        module: MSELoss,
+        g_inp: Tuple[Tensor],
+        g_out: Tuple[Tensor],
+        mc_samples: int = 1,
+        subsampling: List[int] = None,
+    ) -> Tensor:
+        self.check_input_dims(module)
 
-        Attributes:
-            module: (torch.nn.MSELoss) module.
-            g_inp: Gradient of loss w.r.t. input.
-            g_out: Gradient of loss w.r.t. output.
-            mc_samples: (int, optional) Number of MC samples to use. Default: 1.
-
-        Returns:
-            tensor:
-        """
         N, D = module.input0.shape
-        samples = normal(0, 1, size=[mc_samples, N, D], device=module.input0.device)
+        N_active = N if subsampling is None else len(subsampling)
+        samples = normal(
+            0, 1, size=[mc_samples, N_active, D], device=module.input0.device
+        )
         samples *= sqrt(2) / sqrt(mc_samples)
 
         if module.reduction == "mean":

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -79,3 +79,4 @@ test/core/derivatives/pooling_adaptive_settings.py
 test/core/derivatives/batch_norm_settings.py
 test/utils/evaluation_mode.py
 test/utils/skip_test.py
+test/utils/__init__.py

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -329,6 +329,11 @@ class AutogradDerivatives(DerivativesImplementation):
 
         If ``subsampling`` is set to ``None``, leaves the Hessian unchanged.
 
+        Args:
+            hessian: The Hessian w.r.t. the module input.
+            input: Module input.
+            subsampling: List of active samples. Default of ``None`` uses all samples.
+
         Returns:
             Sub-sampled Hessian of shape ``[N, *, N, *]`` where ``N`` denotes the
             number of sub-samples, and ``*`` is the input feature shape.

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -2,8 +2,7 @@
 from test.core.derivatives.implementation.base import DerivativesImplementation
 from typing import List
 
-import torch
-from torch import Tensor, cat, stack, zeros, zeros_like
+from torch import Tensor, allclose, backends, cat, stack, zeros, zeros_like
 
 from backpack.hessianfree.hvp import hessian_vector_product
 from backpack.hessianfree.lop import transposed_jacobian_vector_product
@@ -33,7 +32,7 @@ class AutogradDerivatives(DerivativesImplementation):
             # A RuntimeError is thrown for RNNs on CUDA,
             # because PyTorch does not support double-backwards pass for them.
             # This is the recommended workaround.
-            with torch.backends.cudnn.flags(enabled=False):
+            with backends.cudnn.flags(enabled=False):
                 return stack([self.jac_vec_prod(vec) for vec in mat])
 
     def jac_t_vec_prod(self, vec: Tensor, subsampling=None) -> Tensor:  # noqa: D102
@@ -205,7 +204,7 @@ class AutogradDerivatives(DerivativesImplementation):
                     input_requires_grad=True, sample_idx=sample_idx
                 )
 
-                result = torch.zeros(sample.numel(), mat.size(1), device=sample.device)
+                result = zeros(sample.numel(), mat.size(1), device=sample.device)
 
                 for col in range(mat.size(1)):
                     column = mat[:, col].reshape(output.shape)
@@ -225,7 +224,7 @@ class AutogradDerivatives(DerivativesImplementation):
         N = self.problem.input.shape[0]
         input_features = self.problem.input.shape.numel() // N
 
-        result = torch.zeros(input_features, input_features).to(self.problem.device)
+        result = zeros(input_features, input_features).to(self.problem.device)
 
         for n in range(N):
             result += _sample_jac_t_mat_jac_prod(n, mat)
@@ -252,11 +251,11 @@ class AutogradDerivatives(DerivativesImplementation):
         vectorized_shape = (x.numel(), x.numel())
         final_shape = (*x.shape, *x.shape)
 
-        hessian_vec_x = torch.zeros(vectorized_shape).to(loss.device)
+        hessian_vec_x = zeros(vectorized_shape).to(loss.device)
 
         num_cols = hessian_vec_x.shape[1]
         for column_idx in range(num_cols):
-            unit = torch.zeros(num_cols).to(loss.device)
+            unit = zeros(num_cols).to(loss.device)
             unit[column_idx] = 1.0
 
             unit = unit.view_as(x)
@@ -294,7 +293,7 @@ class AutogradDerivatives(DerivativesImplementation):
             try:
                 yield self._hessian(t, x)
             except (RuntimeError, AttributeError):
-                yield torch.zeros(*x.shape, *x.shape, device=x.device, dtype=x.dtype)
+                yield zeros(*x.shape, *x.shape, device=x.device, dtype=x.dtype)
 
     def hessian_is_zero(self) -> bool:  # noqa: D102
         input, output, _ = self.problem.forward_pass(input_requires_grad=True)
@@ -304,7 +303,7 @@ class AutogradDerivatives(DerivativesImplementation):
             if zero is None:
                 zero = zeros_like(hessian)
 
-            if not torch.allclose(hessian, zero):
+            if not allclose(hessian, zero):
                 return False
 
         return True
@@ -393,9 +392,9 @@ class AutogradDerivatives(DerivativesImplementation):
         N = input.shape[0]
         num_features = input.numel() // N
 
-        sum_hessian = torch.zeros(num_features, num_features, device=input.device)
+        sum_hessian = zeros(num_features, num_features, device=input.device)
 
-        hessian_different_samples = torch.zeros(
+        hessian_different_samples = zeros(
             num_features, num_features, device=input.device
         )
         for n_1 in range(N):
@@ -406,6 +405,6 @@ class AutogradDerivatives(DerivativesImplementation):
                     sum_hessian += block
 
                 else:
-                    assert torch.allclose(block, hessian_different_samples)
+                    assert allclose(block, hessian_different_samples)
 
         return sum_hessian

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -191,15 +191,11 @@ class BackpackDerivatives(DerivativesImplementation):
         Raises:
             ValueError: if input is not 2d
         """
-        equation = None
-
         # TODO improve readability
         if sqrt.dim() == 3:
-            equation = "vni,vnj->nij"
+            return einsum("vni,vnj->nij", sqrt, sqrt)
         else:
             raise ValueError("Only 2D inputs are currently supported.")
-
-        return einsum(equation, sqrt, sqrt)
 
     def _embed_sample_hessians(
         self, individual_hessians: Tensor, input: Tensor

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -189,7 +189,7 @@ class BackpackDerivatives(DerivativesImplementation):
             individual full matrix
 
         Raises:
-            ValueError: if input is not 3d
+            ValueError: if input is not 2d
         """
         equation = None
 
@@ -204,7 +204,18 @@ class BackpackDerivatives(DerivativesImplementation):
     def _embed_sample_hessians(
         self, individual_hessians: Tensor, input: Tensor
     ) -> Tensor:
-        """Embed Hessians w.r.t. individual samples into Hessian w.r.t. all samples."""
+        """Embed Hessians w.r.t. individual samples into Hessian w.r.t. all samples.
+
+        Args:
+            individual_hessians: Hessians w.r.t. individual samples in the input.
+            input: Inputs for the individual Hessians.
+
+        Returns:
+            Hessian that contains the individual Hessians as diagonal blocks.
+
+        Raises:
+            ValueError: if input is not 2d
+        """
         hessian_shape = (*input.shape, *input.shape)
         hessian = zeros(hessian_shape, device=input.device)
 

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -217,7 +217,7 @@ class BackpackDerivatives(DerivativesImplementation):
             ValueError: if input is not 2d
         """
         hessian_shape = (*input.shape, *input.shape)
-        hessian = zeros(hessian_shape, device=input.device)
+        hessian = zeros(hessian_shape, device=input.device, dtype=input.dtype)
 
         for idx in range(input.shape[0]):
             if input.dim() == 2:

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -3,8 +3,7 @@ from test.core.derivatives.implementation.base import DerivativesImplementation
 from test.utils import chunk_sizes
 from typing import List
 
-import torch
-from torch import Tensor
+from torch import Tensor, einsum, zeros
 
 from backpack.utils.subsampling import subsample
 
@@ -200,14 +199,14 @@ class BackpackDerivatives(DerivativesImplementation):
         else:
             raise ValueError("Only 2D inputs are currently supported.")
 
-        return torch.einsum(equation, sqrt, sqrt)
+        return einsum(equation, sqrt, sqrt)
 
     def _embed_sample_hessians(
         self, individual_hessians: Tensor, input: Tensor
     ) -> Tensor:
         """Embed Hessians w.r.t. individual samples into Hessian w.r.t. all samples."""
         hessian_shape = (*input.shape, *input.shape)
-        hessian = torch.zeros(hessian_shape, device=input.device)
+        hessian = zeros(hessian_shape, device=input.device)
 
         for idx in range(input.shape[0]):
             if input.dim() == 2:

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -1,9 +1,12 @@
 """Contains derivative calculation with BackPACK."""
 from test.core.derivatives.implementation.base import DerivativesImplementation
+from test.utils import chunk_sizes
 from typing import List
 
 import torch
 from torch import Tensor
+
+from backpack.utils.subsampling import subsample
 
 
 class BackpackDerivatives(DerivativesImplementation):
@@ -131,32 +134,48 @@ class BackpackDerivatives(DerivativesImplementation):
         self.store_forward_io()
         return self.problem.derivative.sum_hessian(self.problem.module, None, None)
 
-    def input_hessian_via_sqrt_hessian(self, mc_samples=None) -> Tensor:
-        """Computes the input hessian.
+    def input_hessian_via_sqrt_hessian(
+        self, mc_samples: int = None, chunks: int = 1, subsampling: List[int] = None
+    ) -> Tensor:
+        """Computes the Hessian w.r.t. to the input from its matrix square root.
 
         Args:
             mc_samples: If int, uses an MC approximation with the specified
                 number of samples. If None, uses the exact hessian. Defaults to None.
+            chunks: Maximum sequential split of the computation. Default: ``1``.
+                Only used if mc_samples is specified.
+            subsampling: Indices of active samples. ``None`` uses all samples.
 
         Returns:
-            hessian
+            Hessian with respect to the input.
         """
         self.store_forward_io()
 
         if mc_samples is not None:
-            sqrt_hessian = self.problem.derivative.sqrt_hessian_sampled(
-                self.problem.module, None, None, mc_samples=mc_samples
+            chunk_samples = chunk_sizes(mc_samples, chunks)
+            chunk_weights = [samples / mc_samples for samples in chunk_samples]
+
+            individual_hessians: Tensor = sum(
+                weight
+                * self._sample_hessians_from_sqrt(
+                    self.problem.derivative.sqrt_hessian_sampled(
+                        self.problem.module,
+                        None,
+                        None,
+                        mc_samples=samples,
+                        subsampling=subsampling,
+                    )
+                )
+                for weight, samples in zip(chunk_weights, chunk_samples)
             )
         else:
             sqrt_hessian = self.problem.derivative.sqrt_hessian(
-                self.problem.module, None, None
+                self.problem.module, None, None, subsampling=subsampling
             )
+            individual_hessians = self._sample_hessians_from_sqrt(sqrt_hessian)
 
-        individual_hessians = self._sample_hessians_from_sqrt(sqrt_hessian)
-
-        return self._embed_sample_hessians(
-            individual_hessians, self.problem.module.input0
-        )
+        input0 = subsample(self.problem.module.input0, subsampling=subsampling)
+        return self._embed_sample_hessians(individual_hessians, input0)
 
     def hessian_is_zero(self) -> bool:  # noqa: D102
         return self.problem.derivative.hessian_is_zero(self.problem.module)
@@ -174,27 +193,25 @@ class BackpackDerivatives(DerivativesImplementation):
             ValueError: if input is not 3d
         """
         equation = None
-        num_axes = len(sqrt.shape)
 
         # TODO improve readability
-        if num_axes == 3:
+        if sqrt.dim() == 3:
             equation = "vni,vnj->nij"
         else:
             raise ValueError("Only 2D inputs are currently supported.")
 
         return torch.einsum(equation, sqrt, sqrt)
 
-    def _embed_sample_hessians(self, individual_hessians, input):
+    def _embed_sample_hessians(
+        self, individual_hessians: Tensor, input: Tensor
+    ) -> Tensor:
+        """Embed Hessians w.r.t. individual samples into Hessian w.r.t. all samples."""
         hessian_shape = (*input.shape, *input.shape)
         hessian = torch.zeros(hessian_shape, device=input.device)
 
-        N = input.shape[0]
-
-        for n in range(N):
-            num_axes = len(input.shape)
-
-            if num_axes == 2:
-                hessian[n, :, n, :] = individual_hessians[n]
+        for idx in range(input.shape[0]):
+            if input.dim() == 2:
+                hessian[idx, :, idx, :] = individual_hessians[idx]
             else:
                 raise ValueError("Only 2D inputs are currently supported.")
 

--- a/test/utils/__init__.py
+++ b/test/utils/__init__.py
@@ -1,0 +1,27 @@
+"""Helper functions for tests."""
+
+from typing import List
+
+
+def chunk_sizes(total_size: int, num_chunks: int) -> List[int]:
+    """Return list containing the sizes of chunks.
+
+    Args:
+        total_size: Total computation work.
+        num_chunks: Maximum number of chunks the work will be split into.
+
+    Returns:
+        List of chunks with split work.
+    """
+    chunk_size = max(total_size // num_chunks, 1)
+
+    if chunk_size == 1:
+        sizes = total_size * [chunk_size]
+    else:
+        equal, rest = divmod(total_size, chunk_size)
+        sizes = equal * [chunk_size]
+
+        if rest != 0:
+            sizes.append(rest)
+
+    return sizes


### PR DESCRIPTION
Prepares the core for #12.

Auxiliary:
- Make sqrt_MC tolerances stricter, add chunking
- Slightly rewrite sqrt_hessian functions for MSELoss