### PR TITLE
[REF] Improve batch axis detection

### DIFF
--- a/backpack/core/derivatives/basederivatives.py
+++ b/backpack/core/derivatives/basederivatives.py
@@ -289,7 +289,7 @@ class BaseDerivatives(ABC):
         """
         shape = list(module.input0.shape)
         if subsampling is not None:
-            shape[get_batch_axis(module)] = len(subsampling)
+            shape[get_batch_axis(module, "input0")] = len(subsampling)
 
         return cls._reshape_like(mat, shape)
 

--- a/backpack/core/derivatives/lstm.py
+++ b/backpack/core/derivatives/lstm.py
@@ -86,7 +86,7 @@ class LSTMDerivatives(BaseParameterDerivatives):
         c_tanh: Tensor = zeros(T, N, H, device=mat.device, dtype=mat.dtype)
         h: Tensor = zeros(T, N, H, device=mat.device, dtype=mat.dtype)
 
-        N_axis = get_batch_axis(module)
+        N_axis = get_batch_axis(module, "input0")
         input0 = subsample(module.input0, dim=N_axis, subsampling=subsampling)
         output = subsample(module.output, dim=N_axis, subsampling=subsampling)
 
@@ -347,7 +347,9 @@ class LSTMDerivatives(BaseParameterDerivatives):
             f"vtnh,tni->v{'' if sum_batch else 'n'}hi",
             IFGO_prod,
             subsample(
-                module.input0, dim=get_batch_axis(module), subsampling=subsampling
+                module.input0,
+                dim=get_batch_axis(module, "input0"),
+                subsampling=subsampling,
             ),
         )
 
@@ -377,7 +379,7 @@ class LSTMDerivatives(BaseParameterDerivatives):
                     zeros(1, N, H, device=mat.device, dtype=mat.dtype),
                     subsample(
                         module.output,
-                        dim=get_batch_axis(module),
+                        dim=get_batch_axis(module, "input0"),
                         subsampling=subsampling,
                     )[0:-1],
                 ],

--- a/backpack/core/derivatives/rnn.py
+++ b/backpack/core/derivatives/rnn.py
@@ -104,7 +104,9 @@ class RNNDerivatives(BaseParameterDerivatives):
             "vtnh,hk->vtnk",
             self._a_jac_t_mat_prod(
                 subsample(
-                    module.output, dim=get_batch_axis(module), subsampling=subsampling
+                    module.output,
+                    dim=get_batch_axis(module, "input0"),
+                    subsampling=subsampling,
                 ),
                 module.weight_hh_l0,
                 mat,
@@ -171,7 +173,9 @@ class RNNDerivatives(BaseParameterDerivatives):
             dim: int = 1
         return self._a_jac_t_mat_prod(
             subsample(
-                module.output, dim=get_batch_axis(module), subsampling=subsampling
+                module.output,
+                dim=get_batch_axis(module, "input0"),
+                subsampling=subsampling,
             ),
             module.weight_hh_l0,
             mat,
@@ -226,7 +230,7 @@ class RNNDerivatives(BaseParameterDerivatives):
             product
         """
         self._check_parameters(module)
-        N_axis = get_batch_axis(module)
+        N_axis = get_batch_axis(module, "input0")
         return einsum(
             "vtnh,tnj->" + ("vhj" if sum_batch else "vnhj"),
             self._a_jac_t_mat_prod(
@@ -260,7 +264,7 @@ class RNNDerivatives(BaseParameterDerivatives):
             product
         """
         self._check_parameters(module)
-        N_axis = get_batch_axis(module)
+        N_axis = get_batch_axis(module, "input0")
         N: int = mat.shape[N_axis + 1]
         H: int = mat.shape[3]
         output = subsample(module.output, dim=N_axis, subsampling=subsampling)

--- a/backpack/core/derivatives/shape_check.py
+++ b/backpack/core/derivatives/shape_check.py
@@ -73,7 +73,7 @@ def _check_like(mat, module, name, diff=1, *args, **kwargs):
     if name in ["output", "input0"] and "subsampling" in kwargs.keys():
         compare = subsample(
             getattr(module, name),
-            dim=get_batch_axis(module),
+            dim=get_batch_axis(module, name),
             subsampling=kwargs["subsampling"],
         )
     else:

--- a/backpack/custom_module/permute.py
+++ b/backpack/custom_module/permute.py
@@ -8,14 +8,17 @@ from torch.nn import Module
 class Permute(Module):
     """Module to permute a tensor."""
 
-    def __init__(self, *dims: Any):
+    def __init__(self, *dims: Any, batch_axis: int = 0):
         """Initialization.
 
         Args:
             dims: The desired ordering of dimensions.
+            batch_axis: Which axis assumed to be the batch axis in a forward pass.
+                Defaults to ``0``.
         """
         super().__init__()
         self.dims = dims
+        self.batch_axis = batch_axis
 
     def forward(self, input: Tensor) -> Tensor:
         """Permutes the input tensor.
@@ -27,3 +30,23 @@ class Permute(Module):
             view with new ordering
         """
         return input.permute(self.dims)
+
+    def get_batch_axis(self, io_str: str) -> int:
+        """Return the batch axis assumed by the module.
+
+        Args:
+            io_str: Name of the tensor. Must be ``'input0'`` or ``'output'``.
+
+        Returns:
+            Batch axis
+
+        Raises:
+            ValueError: For invalid IO names.
+        """
+        if io_str == "input0":
+            return self.batch_axis
+        elif io_str == "output":
+            return self.dims.index(self.batch_axis)
+        else:
+            valid_io_strs = ["input0", "output"]
+            raise ValueError(f"io_str must be in {valid_io_strs}, got {io_str}.")

--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -85,7 +85,9 @@ class BatchGradBase(FirstOrderModuleExtension):
                 g_inp,
                 g_out,
                 subsample(
-                    g_out[0], dim=get_batch_axis(module), subsampling=subsampling
+                    g_out[0],
+                    dim=get_batch_axis(module, "output"),
+                    subsampling=subsampling,
                 ),
                 sum_batch=False,
                 subsampling=subsampling,

--- a/backpack/utils/subsampling.py
+++ b/backpack/utils/subsampling.py
@@ -18,21 +18,11 @@ def subsample(tensor: Tensor, dim: int = 0, subsampling: List[int] = None) -> Te
 
     Returns:
         Tensor of same rank that is sub-sampled along the dimension.
-
-    Raises:
-        NotImplementedError: If dimension differs from ``0, 1, 2``.
     """
     if subsampling is None:
         return tensor
     else:
-        if dim == 0:
-            return tensor[subsampling]
-        elif dim == 1:
-            return tensor[:, subsampling]
-        elif dim == 2:
-            return tensor[:, :, subsampling]
-        else:
-            raise NotImplementedError(f"Only supports dim = 0,1,2. Got {dim}.")
+        return tensor[(slice(None),) * dim + (subsampling,)]
 
 
 def get_batch_axis(module: Module, io_str: str) -> int:

--- a/backpack/utils/subsampling.py
+++ b/backpack/utils/subsampling.py
@@ -20,7 +20,7 @@ def subsample(tensor: Tensor, dim: int = 0, subsampling: List[int] = None) -> Te
         Tensor of same rank that is sub-sampled along the dimension.
 
     Raises:
-        NotImplementedError: If dimension differs from ``0`` or ``1``.
+        NotImplementedError: If dimension differs from ``0, 1, 2``.
     """
     if subsampling is None:
         return tensor
@@ -29,8 +29,10 @@ def subsample(tensor: Tensor, dim: int = 0, subsampling: List[int] = None) -> Te
             return tensor[subsampling]
         elif dim == 1:
             return tensor[:, subsampling]
+        elif dim == 2:
+            return tensor[:, :, subsampling]
         else:
-            raise NotImplementedError(f"Only supports dim = 0,1. Got {dim}.")
+            raise NotImplementedError(f"Only supports dim = 0,1,2. Got {dim}.")
 
 
 def get_batch_axis(module: Module, io_str: str) -> int:

--- a/backpack/utils/subsampling.py
+++ b/backpack/utils/subsampling.py
@@ -2,7 +2,9 @@
 from typing import List
 
 from torch import Tensor
-from torch.nn import LSTM, RNN, Module
+from torch.nn import LSTM, RNN, Module, Sequential
+
+from backpack.custom_module.permute import Permute
 
 
 def subsample(tensor: Tensor, dim: int = 0, subsampling: List[int] = None) -> Tensor:
@@ -31,19 +33,41 @@ def subsample(tensor: Tensor, dim: int = 0, subsampling: List[int] = None) -> Te
             raise NotImplementedError(f"Only supports dim = 0,1. Got {dim}.")
 
 
-def get_batch_axis(module: Module) -> int:
+def get_batch_axis(module: Module, io_str: str) -> int:
     """Return the batch axis assumed by the module.
+
+    For unknown modules the default axis is determined as ``0``.
 
     Args:
         module: A module.
+        io_str: Name of the tensor stored as BackPACK IO. Must be ``'input0'`` or
+            ``'output'``.
+
+    Note:
+        This method only inspects single modules and therefore cannot detect whether
+        the batch axis has been modified by preceding ones. For instance for a ReLU
+        module, the batch axis will always be detected as ``0``, although the layer
+        still works if preceded by a ``Permute(0, 1)`` module, but would have batch
+        axis ``1``.
 
     Returns:
         Batch axis
+
+    Raises:
+        ValueError: For invalid IO names.
     """
+    valid_io_strs = ["input0", "output"]
+    if io_str not in valid_io_strs:
+        raise ValueError(f"io_str must be in {valid_io_strs}, got {io_str}.")
+
+    batch_axis = 0
+
     if isinstance(module, (RNN, LSTM)):
-        if module.batch_first:
-            return 0
-        else:
-            return 1
-    else:
-        return 0
+        batch_axis = 0 if module.batch_first else 1
+    elif isinstance(module, Permute):
+        batch_axis = module.get_batch_axis(io_str)
+    elif isinstance(module, Sequential):
+        child_idx = {"input0": 0, "output": -1}[io_str]
+        batch_axis = get_batch_axis(list(module.children())[child_idx], io_str)
+
+    return batch_axis

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -89,3 +89,5 @@ test/core/derivatives/batch_norm_settings.py
 test/utils/evaluation_mode.py
 test/utils/skip_test.py
 test/utils/__init__.py
+test/utils/test_subsampling.py
+test/custom_module/

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -187,7 +187,7 @@ def rand_mat_like_output(
     subsample_shape = list(problem.output_shape)
 
     if subsampling is not None:
-        N_axis = get_batch_axis(problem.module)
+        N_axis = get_batch_axis(problem.module, "output")
         subsample_shape[N_axis] = len(subsampling)
 
     return rand(V, *subsample_shape, device=problem.device)

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -20,7 +20,6 @@ from test.core.derivatives.settings import SETTINGS
 from test.utils.skip_test import (
     skip_adaptive_avg_pool3d_cuda,
     skip_batch_norm_train_mode_with_subsampling,
-    skip_permute_with_subsampling,
     skip_subsampling_conflict,
 )
 from typing import List, Union
@@ -144,7 +143,6 @@ def test_jac_t_mat_prod(
     skip_adaptive_avg_pool3d_cuda(request)
 
     problem.set_up()
-    skip_permute_with_subsampling(problem, subsampling)
     skip_batch_norm_train_mode_with_subsampling(problem, subsampling)
     skip_subsampling_conflict(problem, subsampling)
     mat = rand_mat_like_output(V, problem, subsampling=subsampling)

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -43,7 +43,7 @@ class AutogradDerivatives(DerivativesImplementation):
         else:
             # for each sample, multiply by full input Jacobian, slice out result:
             # ( (∂ output[n] / ∂ input)ᵀ v[n] )[n]
-            batch_axis = get_batch_axis(self.problem.module)
+            batch_axis = get_batch_axis(self.problem.module, "output")
             output = subsample(output, dim=batch_axis, subsampling=subsampling)
             output = output.split(1, dim=batch_axis)
             vec = vec.split(1, dim=batch_axis)
@@ -75,7 +75,7 @@ class AutogradDerivatives(DerivativesImplementation):
                     param_str,
                     vec,
                     sum_batch,
-                    axis_batch=get_batch_axis(self.problem.module),
+                    axis_batch=get_batch_axis(self.problem.module, "output"),
                     subsampling=subsampling,
                 )
                 for vec in mat

--- a/test/core/derivatives/problem.py
+++ b/test/core/derivatives/problem.py
@@ -2,11 +2,14 @@
 
 import copy
 from test.core.derivatives.utils import derivative_cls_for, get_available_devices
+from typing import Dict, Tuple
 
 import torch
+from torch import Tensor
 
 from backpack import extend
 from backpack.utils.module_classification import is_loss
+from backpack.utils.subsampling import get_batch_axis, subsample
 
 
 def make_test_problems(settings):
@@ -138,25 +141,27 @@ class DerivativesTestProblem:
     def is_loss(self):
         return is_loss(self.make_module())
 
-    def forward_pass(self, input_requires_grad=False, sample_idx=None):
+    def forward_pass(
+        self, input_requires_grad: bool = False, sample_idx: int = None
+    ) -> Tuple[Tensor, Tensor, Dict[str, Tensor]]:
         """Do a forward pass. Return input, output, and parameters."""
-        if sample_idx is None:
-            input = self.input.clone().detach()
-        else:
-            input = self.input.clone()[sample_idx, :].unsqueeze(0).detach()
+        input: Tensor = self.input.clone().detach()
+        if sample_idx is not None:
+            batch_axis_in = get_batch_axis(self.module, "input0")
+            input = subsample(input, dim=batch_axis_in, subsampling=[sample_idx])
 
         if input_requires_grad:
             input.requires_grad = True
 
         if self.is_loss():
             assert sample_idx is None
-            output = self.module(input, self.target)
+            output: Tensor = self.module(input, self.target)
         else:
-            output = self.module(input)
+            output: Tensor = self.module(input)
 
         if isinstance(output, tuple):
             # is true for RNN,GRU,LSTM which return tuple (output, ...)
-            output = output[0]
+            output: Tensor = output[0]
 
         return input, output, dict(self.module.named_parameters())
 

--- a/test/custom_module/__init__.py
+++ b/test/custom_module/__init__.py
@@ -1,0 +1,1 @@
+"""Contains tests for BackPACK's custom modules."""

--- a/test/custom_module/test_permute.py
+++ b/test/custom_module/test_permute.py
@@ -1,0 +1,25 @@
+"""Contains tests for BackPACK's custom ``Permute`` module."""
+
+from pytest import raises
+
+from backpack.custom_module.permute import Permute
+
+
+def test_get_batch_axis():
+    """Test the Permute module's batch axis detection."""
+    # invalid argument
+    with raises(ValueError):
+        invalid_io_str = "dummy"
+        Permute().get_batch_axis(invalid_io_str)
+
+    # batch axis unaffected by forward pass
+    assert Permute(0, 2, 1).get_batch_axis("input0") == 0
+    assert Permute(0, 2, 1).get_batch_axis("output") == 0
+
+    # batch axis first, affected by forward pass
+    assert Permute(1, 2, 0).get_batch_axis("input0") == 0
+    assert Permute(1, 2, 0).get_batch_axis("output") == 2
+
+    # batch axis second, affected by forward pass
+    assert Permute(1, 2, 0, batch_axis=1).get_batch_axis("input0") == 1
+    assert Permute(1, 2, 0, batch_axis=1).get_batch_axis("output") == 0

--- a/test/extensions/firstorder/firstorder_settings.py
+++ b/test/extensions/firstorder/firstorder_settings.py
@@ -260,10 +260,10 @@ FIRSTORDER_SETTINGS += [
     {
         "input_fn": lambda: rand(8, 5, 6),
         "module_fn": lambda: Sequential(
-            Permute(1, 0, 2),
+            Permute(1, 0, 2, batch_axis=0),
             RNN(input_size=6, hidden_size=3),
             ReduceTuple(index=0),
-            Permute(1, 2, 0),
+            Permute(1, 2, 0, batch_axis=1),
         ),
         "loss_function_fn": lambda: CrossEntropyLoss(reduction="mean"),
         "target_fn": lambda: classification_targets((8, 5), 3),
@@ -271,10 +271,10 @@ FIRSTORDER_SETTINGS += [
     {
         "input_fn": lambda: rand(8, 5, 6),
         "module_fn": lambda: Sequential(
-            Permute(1, 0, 2),
+            Permute(1, 0, 2, batch_axis=0),
             RNN(input_size=6, hidden_size=3),
             ReduceTuple(index=0),
-            Permute(1, 2, 0),
+            Permute(1, 2, 0, batch_axis=1),
             Flatten(),
         ),
         "loss_function_fn": lambda: MSELoss(),

--- a/test/extensions/implementation/autograd.py
+++ b/test/extensions/implementation/autograd.py
@@ -17,7 +17,7 @@ class AutogradExtensions(ExtensionsImplementation):
     def batch_grad(
         self, subsampling: Union[List[int], None]
     ) -> List[Tensor]:  # noqa: D102
-        N = self.problem.input.shape[get_batch_axis(self.problem.model)]
+        N = self.problem.input.shape[get_batch_axis(self.problem.model, "input0")]
         samples = list(range(N)) if subsampling is None else subsampling
 
         loss_list = zeros(N)

--- a/test/extensions/problem.py
+++ b/test/extensions/problem.py
@@ -150,7 +150,6 @@ class ExtensionsTestProblem:
         else:
             batch_axis_in = get_batch_axis(self.model, "input0")
             batch_axis_out = get_batch_axis(self.model, "output")
-            assert batch_axis_in == batch_axis_out
             target = subsample(
                 self.target, dim=batch_axis_out, subsampling=[sample_idx]
             )

--- a/test/extensions/problem.py
+++ b/test/extensions/problem.py
@@ -2,12 +2,14 @@
 
 import copy
 from test.core.derivatives.utils import get_available_devices
-from typing import Any, Iterator, List
+from typing import Any, Iterator, List, Tuple
 
 import torch
+from torch import Tensor
 from torch.nn.parameter import Parameter
 
 from backpack import extend
+from backpack.utils.subsampling import get_batch_axis, subsample
 
 
 def make_test_problems(settings):
@@ -130,26 +132,29 @@ class ExtensionsTestProblem:
             ).replace(" ", "")
         )
 
-    def forward_pass(self, sample_idx=None):
+    def forward_pass(self, sample_idx: int = None) -> Tuple[Tensor, Tensor, Tensor]:
         """Do a forward pass. Return input, output, and parameters.
 
         The forward pass is performed on the selected index.
         If the index is None, then the forward pass is calculated for the whole batch.
 
         Args:
-            sample_idx (int, optional): Index of the sample to select.
-                Defaults to None.
+            sample_idx: Index of the sample to select. Defaults to ``None``.
 
         Returns:
-            tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-                input, output, loss, each with batch axis first
+            input, output, loss, each with batch axis first
         """
         if sample_idx is None:
             input = self.input.clone()
             target = self.target.clone()
         else:
-            target = self.target.split(1, dim=0)[sample_idx]
-            input = self.input.split(1, dim=0)[sample_idx]
+            batch_axis_in = get_batch_axis(self.model, "input0")
+            batch_axis_out = get_batch_axis(self.model, "output")
+            assert batch_axis_in == batch_axis_out
+            target = subsample(
+                self.target, dim=batch_axis_out, subsampling=[sample_idx]
+            )
+            input = subsample(self.input, dim=batch_axis_in, subsampling=[sample_idx])
 
         output = self.model(input)
 

--- a/test/extensions/secondorder/diag_ggn/diag_ggn_settings.py
+++ b/test/extensions/secondorder/diag_ggn/diag_ggn_settings.py
@@ -42,10 +42,10 @@ LOCAL_SETTINGS += [
     {
         "input_fn": lambda: rand(8, 5, 6),
         "module_fn": lambda: Sequential(
-            Permute(1, 0, 2),
+            Permute(1, 0, 2, batch_axis=0),
             RNN(input_size=6, hidden_size=3),
             ReduceTuple(index=0),
-            Permute(1, 2, 0),
+            Permute(1, 2, 0, batch_axis=1),
             Flatten(),
         ),
         "loss_function_fn": lambda: MSELoss(),

--- a/test/extensions/utils.py
+++ b/test/extensions/utils.py
@@ -17,7 +17,7 @@ def skip_if_subsampling_conflict(
         problem: Test case.
         subsampling: Indices of active samples.
     """
-    N = problem.input.shape[get_batch_axis(problem.model)]
+    N = problem.input.shape[get_batch_axis(problem.model, "input0")]
     enough_samples = subsampling is None or N > max(subsampling)
     if not enough_samples:
         skip(f"Not enough samples: N={N}, subsampling={subsampling}")

--- a/test/utils/skip_test.py
+++ b/test/utils/skip_test.py
@@ -68,7 +68,7 @@ def skip_subsampling_conflict(
         problem: Test case.
         subsampling: Indices of active samples.
     """
-    N = problem.input_shape[get_batch_axis(problem.module)]
+    N = problem.input_shape[get_batch_axis(problem.module, "input0")]
     enough_samples = subsampling is None or N > max(subsampling)
     if not enough_samples:
         skip("Not enough samples.")

--- a/test/utils/skip_test.py
+++ b/test/utils/skip_test.py
@@ -6,7 +6,6 @@ from typing import List, Union
 from pytest import skip
 from torch.nn import BatchNorm1d, BatchNorm2d, BatchNorm3d
 
-from backpack.custom_module.permute import Permute
 from backpack.utils import TORCH_VERSION_AT_LEAST_1_9_1
 from backpack.utils.subsampling import get_batch_axis
 
@@ -28,21 +27,6 @@ def skip_adaptive_avg_pool3d_cuda(request) -> None:
                 "Skip test because AdaptiveAvgPool3d does not work on cuda. "
                 "Is fixed in torch 1.9.1."
             )
-
-
-def skip_permute_with_subsampling(
-    problem: DerivativesTestProblem, subsampling: Union[List[int], None]
-) -> None:
-    """Skip Permute module when sub-sampling is turned on.
-
-    Permute does not assume a batch axis.
-
-    Args:
-        problem: Test case.
-        subsampling: Indices of active samples.
-    """
-    if isinstance(problem.module, Permute) and subsampling is not None:
-        skip(f"Skipping Permute with sub-sampling: {subsampling}")
 
 
 def skip_batch_norm_train_mode_with_subsampling(

--- a/test/utils/test_subsampling.py
+++ b/test/utils/test_subsampling.py
@@ -1,10 +1,11 @@
 """Contains tests of sub-sampling functionality."""
 
 from pytest import raises
+from torch import allclose, manual_seed, rand
 from torch.nn import Linear, ReLU, Sequential
 
 from backpack.custom_module.permute import Permute
-from backpack.utils.subsampling import get_batch_axis
+from backpack.utils.subsampling import get_batch_axis, subsample
 
 
 def test_get_batch_axis():
@@ -35,3 +36,20 @@ def test_get_batch_axis():
     # expected failure due to local inspection
     batch_axis_output = 1
     assert get_batch_axis(model, "output") != batch_axis_output
+
+
+def test_subsample():
+    """Test slicing operations for sub-sampling a tensor's batch axis."""
+    manual_seed(0)
+    tensor = rand(3, 4, 5, 6)
+
+    # leave tensor untouched when `subsampling = None`
+    assert id(subsample(tensor)) == id(tensor)
+    assert allclose(subsample(tensor), tensor)
+
+    # slice along correct dimension
+    idx = [2, 0]
+    assert allclose(subsample(tensor, dim=0, subsampling=idx), tensor[idx])
+    assert allclose(subsample(tensor, dim=1, subsampling=idx), tensor[:, idx])
+    assert allclose(subsample(tensor, dim=2, subsampling=idx), tensor[:, :, idx])
+    assert allclose(subsample(tensor, dim=3, subsampling=idx), tensor[:, :, :, idx])

--- a/test/utils/test_subsampling.py
+++ b/test/utils/test_subsampling.py
@@ -1,0 +1,37 @@
+"""Contains tests of sub-sampling functionality."""
+
+from pytest import raises
+from torch.nn import Linear, ReLU, Sequential
+
+from backpack.custom_module.permute import Permute
+from backpack.utils.subsampling import get_batch_axis
+
+
+def test_get_batch_axis():
+    """Test batch axis detection."""
+    # invalid argument
+    with raises(ValueError):
+        invalid_io_str = "dummy"
+        some_module = Linear(1, 1)
+        get_batch_axis(some_module, invalid_io_str)
+
+    # Sequential with unaltered batch axis
+    model = Sequential(Linear(1, 1), ReLU())
+    assert get_batch_axis(model, "input0") == 0
+    assert get_batch_axis(model, "output") == 0
+
+    # Sequential with altered batch axis
+    model = Sequential(Linear(1, 1), Permute(1, 0))
+    assert get_batch_axis(model, "input0") == 0
+    assert get_batch_axis(model, "output") == 1
+
+    # Permute
+    model = Permute(1, 3, 2, 0, batch_axis=0)
+    assert get_batch_axis(model, "input0") == 0
+    assert get_batch_axis(model, "output") == 3
+
+    model = Sequential(Permute(0, 1), ReLU())
+    assert get_batch_axis(model, "input0") == 0
+    # expected failure due to local inspection
+    batch_axis_output = 1
+    assert get_batch_axis(model, "output") != batch_axis_output


### PR DESCRIPTION
Sub-sampling relies on slicing tensors along their batch axis. So far we detect
the batch axis based on the module. However, BackPACK's custom `Permute`
module can alter the axes of its input tensor and therefore modify the batch axis
position. To account for this, the batch axis not only has to be determined based
on the module, but also on the direction of the tensor, i.e. `input` or `output`.

This PR introduces such a tensor-agnostic batch size detection. Progress on #12:
- Replace hard-coded batch axes in tests with dynamical ones
- Make `jac_t_mat_prod` tests work for `Permute` module
- Support arbitrary batch axes in `subsample`