### PR TITLE
retain_graph=True (search variable in stack)

### DIFF
--- a/backpack/__init__.py
+++ b/backpack/__init__.py
@@ -205,7 +205,10 @@ def hook_run_extensions(
         print("[DEBUG] Running extension hook on", module)
     CTX.get_extension_hook()(module)
 
-    if not (
+    # could be made more precise to check for backward/grad
+    fr = [f[0] for f in inspect.stack() if "/torch/autograd/" in f.filename][-1]
+    retain_graph = inspect.getargvalues(fr).locals["retain_graph"]
+    if not retain_graph and not (
         CTX.is_extension_active(
             extensions.curvmatprod.HMP,
             extensions.curvmatprod.GGNMP,

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1,0 +1,45 @@
+"""Test autograd functionality like retain_graph."""
+from pytest import raises
+from torch import rand, randint
+from torch.nn import CrossEntropyLoss, Linear, Module, Sequential
+
+from backpack import extend
+
+
+def test_retain_graph():
+    model = extend(Sequential(Linear(4, 6), Linear(6, 5)))
+    loss_fn = extend(CrossEntropyLoss())
+
+    # after a forward pass graph is not clear
+    loss = loss_fn(model(rand(8, 4)), randint(5, (8,)))
+    with raises(AssertionError):
+        _clear_input_output(model)
+
+    # after a normal backward pass graph should be clear
+    loss.backward()
+    _clear_input_output(model)
+
+    # after a backward pass with retain_graph=True graph is not clear
+    loss = loss_fn(model(rand(8, 4)), randint(5, (8,)))
+    loss.backward(retain_graph=True)
+    with raises(AssertionError):
+        _clear_input_output(model)
+
+    # doing several backward passes with retain_graph=True
+    for _ in range(3):
+        loss.backward(retain_graph=True)
+
+    # finally doing a normal backward pass that verifies graph is clear again
+    loss.backward()
+    _clear_input_output(model)
+
+
+def _clear_input_output(parent_module: Module) -> bool:
+    if list(parent_module.children()):
+        return all([_clear_input_output(module) for module in parent_module.children()])
+    elif hasattr(parent_module, "input0") or hasattr(parent_module, "output"):
+        raise AssertionError(
+            f"graph should be clear, but {parent_module} has input0 or output."
+        )
+    else:
+        return True


### PR DESCRIPTION
Handle the case where `retain_graph=True`.
This fixes https://github.com/f-dangel/backpack/issues/213
and fixes first half of https://github.com/fKunstner/backpack-discuss/issues/115

This solution was suggested to me in https://discuss.pytorch.org/t/infer-value-of-retain-graph-and-create-graph/130622

Runtime overhead:
A noticed a significant runtime overhead: the test runtime increased from ~5min to ~18min.
In [this stackoverflow post](https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow), the `inspect.stack()` call had a runtime of 5e-3s. 
Using `inspect.stack(0)` instead, reduced the overhead by a factor of 5. For our case, tests would then run in ~7.6 min.
The other suggestion is to use a recursive scheme, that only inspects the previous frame via `frame.f_back`. I'm not sure how many recursive calls would be needed to reach the frame that is `autograd`.

CUDA:
This function does not work on CUDA!

Convert to draft. Eventually close, unless there is a new idea coming up.