### PR TITLE
RNN converter

### DIFF
--- a/backpack/core/derivatives/embedding.py
+++ b/backpack/core/derivatives/embedding.py
@@ -1,0 +1,74 @@
+"""Derivatives for Embedding."""
+from typing import List, Tuple
+
+from torch import Tensor, einsum, zeros
+from torch.nn import Embedding
+
+from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
+from backpack.utils import TORCH_VERSION_AT_LEAST_1_9_0
+from backpack.utils.subsampling import subsample
+
+
+class EmbeddingDerivatives(BaseParameterDerivatives):
+    """Derivatives for Embedding.
+
+    Note:
+        These derivatives assume the batch axis to be at position 0.
+
+    Index convention:
+    v - free axis
+    n - batch axis
+    s - num_embeddings
+    h - embedding_dim
+    """
+
+    def _jac_t_mat_prod(
+        self,
+        module: Embedding,
+        g_inp: Tuple[Tensor],
+        g_out: Tuple[Tensor],
+        mat: Tensor,
+        subsampling: List[int] = None,
+    ) -> Tensor:
+        raise NotImplementedError(
+            "Derivative w.r.t. input not defined: Input to Embedding has type long."
+            " But only float and complex dtypes can require gradients in PyTorch."
+        )
+
+    def _weight_jac_t_mat_prod(
+        self,
+        module: Embedding,
+        g_inp: Tuple[Tensor],
+        g_out: Tuple[Tensor],
+        mat: Tensor,
+        sum_batch: bool = True,
+        subsampling: List[int] = None,
+    ) -> Tensor:
+        self._check_parameters(module)
+
+        input0 = subsample(module.input0, subsampling=subsampling)
+        delta = zeros(module.num_embeddings, *input0.shape, device=mat.device)
+        for s in range(module.num_embeddings):
+            delta[s] = input0 == s
+        if TORCH_VERSION_AT_LEAST_1_9_0:
+            equation = f"sn...,vn...h->v{'' if sum_batch else 'n'}sh"
+        elif delta.dim() == 2:
+            equation = f"sn,vnh->v{'' if sum_batch else 'n'}sh"
+        else:
+            equation = f"snx,vnxh->v{'' if sum_batch else 'n'}sh"
+            delta = delta.flatten(start_dim=2, end_dim=-1)
+            mat = mat.flatten(start_dim=2, end_dim=-2)
+        return einsum(equation, delta, mat)
+
+    def _check_parameters(self, module: Embedding) -> None:
+        if module.padding_idx is not None:
+            raise NotImplementedError("Only padding_idx=None supported.")
+        elif module.max_norm is not None:
+            raise NotImplementedError("Only max_norm=None supported.")
+        elif module.scale_grad_by_freq:
+            raise NotImplementedError("Only scale_grad_by_freq=False supported.")
+        elif module.sparse:
+            raise NotImplementedError("Only sparse=False supported.")
+
+    def hessian_is_zero(self, module: Embedding) -> bool:  # noqa: D102
+        return False

--- a/backpack/custom_module/graph_utils.py
+++ b/backpack/custom_module/graph_utils.py
@@ -1,11 +1,14 @@
 """Transformation tools to make graph BackPACK compatible."""
 from copy import deepcopy
+from typing import Tuple
 from warnings import warn
 
 from torch.fx import Graph, GraphModule, Node, Tracer
-from torch.nn import Flatten, Module
+from torch.nn import LSTM, Dropout, Flatten, Module, Sequential
 
 from backpack.custom_module.branching import ActiveIdentity, SumModule, _Branch
+from backpack.custom_module.permute import Permute
+from backpack.custom_module.reduce_tuple import ReduceTuple
 from backpack.custom_module.scale_module import ScaleModule
 from backpack.utils import TORCH_VERSION_AT_LEAST_1_9_0
 
@@ -16,7 +19,9 @@ class BackpackTracer(Tracer):
     def is_leaf_module(
         self, m: Module, module_qualified_name: str
     ) -> bool:  # noqa: D102
-        if isinstance(m, (ScaleModule, SumModule, _Branch, ActiveIdentity)):
+        if isinstance(
+            m, (ScaleModule, SumModule, _Branch, ActiveIdentity, ReduceTuple, Permute)
+        ):
             return True
         else:
             return super().is_leaf_module(m, module_qualified_name)
@@ -29,7 +34,11 @@ def convert_module_to_backpack(module: Module, debug: bool) -> GraphModule:
     - mul -> ScaleModule
     - add -> AddModule
     - flatten -> nn.Flatten
-    - inplace to normal
+    - getitem -> ReduceTuple
+    - permute -> Permute
+    - transpose -> Transpose
+    - LSTM: split multiple layers
+    - inplace -> normal
     - remove duplicates
     - delete unused modules
     - check BackPACK compatible
@@ -52,8 +61,12 @@ def convert_module_to_backpack(module: Module, debug: bool) -> GraphModule:
     if debug:
         print("\nMake module BackPACK-compatible...")
     module_new = _transform_mul_to_scale_module(module, debug)
-    module_new = _transform_flatten_to_module(module_new, debug)
+    module_new = _transform_flatten_to_module(module_new, debug)  # TODO allow function
     module_new = _transform_add_to_sum_module(module_new, debug)
+    module_new = _transform_get_item_to_module(module_new, debug)
+    module_new = _transform_permute_to_module(module_new, debug)
+    # TODO convert transpose similar to permute
+    module_new = _transform_lstm(module_new, debug)
     _transform_inplace_to_normal(module_new, debug)
     module_new = _transform_remove_duplicates(module_new, debug)
     if debug:
@@ -199,6 +212,115 @@ def _transform_flatten_to_module(module: Module, debug: bool) -> GraphModule:
         print(f"\tFlatten transformed: {len(nodes)}")
 
     return GraphModule(module, graph)
+
+
+def _transform_get_item_to_module(module: Module, debug: bool) -> GraphModule:
+    target = "<built-in function getitem>"
+    if debug:
+        print(f"\tBegin transformation: {target} -> ReduceTuple")
+    counter: int = 0
+    graph: Graph = BackpackTracer().trace(module)
+
+    for node in graph.nodes:
+        if node.op == "call_function" and target in str(node.target):
+            _change_node_to_module(
+                node,
+                "reduce_tuple",
+                module,
+                ReduceTuple(index=node.args[1]),
+                (node.args[0],),
+            )
+            counter += 1
+
+    graph.lint()
+    if debug:
+        print(f"\tReduceTuple transformed: {counter}")
+    return GraphModule(module, graph)
+
+
+def _transform_permute_to_module(module: Module, debug: bool) -> GraphModule:
+    target1 = "permute"
+    target2 = "<built-in method permute"
+    if debug:
+        print(f"\tBegin transformation: {target1}|{target2} -> Permute")
+    counter: int = 0
+    graph: Graph = BackpackTracer().trace(module)
+
+    for node in graph.nodes:
+        if (node.op == "call_function" and target2 in str(node.target)) or (
+            node.op == "call_method" and target1 == str(node.target)
+        ):
+            _change_node_to_module(
+                node,
+                "permute",
+                module,
+                Permute(*node.args[1])
+                if len(node.args) == 2
+                else Permute(*node.args[1:]),
+                (node.args[0],),
+            )
+            counter += 1
+
+    graph.lint()
+    if debug:
+        print(f"\tPermute transformed: {counter}")
+    return GraphModule(module, graph)
+
+
+def _transform_lstm(module: Module, debug: bool) -> GraphModule:
+    if debug:
+        print("\tBegin transformation: LSTM")
+    counter: int = 0
+    graph: Graph = BackpackTracer().trace(module)
+
+    for node in graph.nodes:
+        if node.op == "call_module" and isinstance(
+            module.get_submodule(node.target), LSTM
+        ):
+            lstm_module: LSTM = module.get_submodule(node.target)
+            if lstm_module.num_layers > 1:
+                if len(node.args) > 1:
+                    raise NotImplementedError(
+                        "For conversion, input of LSTM must not have hidden states."
+                    )
+                lstm_module_replace = _make_lstm_backpack(lstm_module)
+                module.add_module(node.target, lstm_module_replace)
+                counter += 1
+
+    graph.lint()
+    if debug:
+        print(f"\tLSTMs transformed: {counter}")
+    return GraphModule(module, graph)
+
+
+def _lstm_hyperparams(module: LSTM) -> Tuple[int, int, float, bool]:
+    if module.bias is not True:
+        raise NotImplementedError("only bias = True is supported")
+    if module.bidirectional is not False:
+        raise NotImplementedError("only bidirectional = False is supported")
+    if module.proj_size != 0:
+        raise NotImplementedError("only proj_size = 0 is supported")
+    return module.input_size, module.hidden_size, module.dropout, module.batch_first
+
+
+def _make_lstm_backpack(module: LSTM) -> Module:
+    input_size, hidden_size, dropout, batch_first = _lstm_hyperparams(module)
+    lstm_module_replace = Sequential()
+    for layer in range(module.num_layers):
+        lstm_layer = LSTM(
+            input_size if layer == 0 else hidden_size,
+            hidden_size,
+            batch_first=batch_first,
+        )
+        for param_str in ["weight_ih_l", "weight_hh_l", "bias_ih_l", "bias_hh_l"]:
+            setattr(lstm_layer, f"{param_str}0", getattr(module, f"{param_str}{layer}"))
+        lstm_module_replace.add_module(f"lstm_{layer}", lstm_layer)
+        if layer != (module.num_layers - 1):
+            lstm_module_replace.add_module(f"reduce_tuple_{layer}", ReduceTuple())
+            if dropout != 0:
+                lstm_module_replace.add_module(f"dropout_{layer}", Dropout(dropout))
+    lstm_module_replace.train(module.training)
+    return lstm_module_replace
 
 
 def _transform_inplace_to_normal(

--- a/backpack/extensions/firstorder/batch_grad/__init__.py
+++ b/backpack/extensions/firstorder/batch_grad/__init__.py
@@ -16,6 +16,7 @@ from torch.nn import (
     ConvTranspose1d,
     ConvTranspose2d,
     ConvTranspose3d,
+    Embedding,
     Linear,
 )
 
@@ -29,6 +30,7 @@ from . import (
     conv_transpose1d,
     conv_transpose2d,
     conv_transpose3d,
+    embedding,
     linear,
     rnn,
 )
@@ -82,6 +84,7 @@ class BatchGrad(FirstOrderBackpropExtension):
                 BatchNorm3d: batchnorm_nd.BatchGradBatchNormNd(),
                 RNN: rnn.BatchGradRNN(),
                 LSTM: rnn.BatchGradLSTM(),
+                Embedding: embedding.BatchGradEmbedding(),
             },
             subsampling=subsampling,
         )

--- a/backpack/extensions/firstorder/batch_grad/embedding.py
+++ b/backpack/extensions/firstorder/batch_grad/embedding.py
@@ -1,0 +1,11 @@
+"""BatchGrad extension for Embedding."""
+from backpack.core.derivatives.embedding import EmbeddingDerivatives
+from backpack.extensions.firstorder.batch_grad.batch_grad_base import BatchGradBase
+
+
+class BatchGradEmbedding(BatchGradBase):
+    """BatchGrad extension for Embedding."""
+
+    def __init__(self):
+        """Initialization."""
+        super().__init__(derivatives=EmbeddingDerivatives(), params=["weight"])

--- a/backpack/extensions/firstorder/batch_l2_grad/__init__.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/__init__.py
@@ -15,6 +15,7 @@ from torch.nn import (
     ConvTranspose1d,
     ConvTranspose2d,
     ConvTranspose3d,
+    Embedding,
     Linear,
 )
 
@@ -23,6 +24,7 @@ from backpack.extensions.firstorder.batch_l2_grad import (
     batchnorm_nd,
     convnd,
     convtransposend,
+    embedding,
     linear,
     rnn,
 )
@@ -66,5 +68,6 @@ class BatchL2Grad(FirstOrderBackpropExtension):
                 BatchNorm1d: batchnorm_nd.BatchL2BatchNorm(),
                 BatchNorm2d: batchnorm_nd.BatchL2BatchNorm(),
                 BatchNorm3d: batchnorm_nd.BatchL2BatchNorm(),
+                Embedding: embedding.BatchL2Embedding(),
             },
         )

--- a/backpack/extensions/firstorder/batch_l2_grad/embedding.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/embedding.py
@@ -1,0 +1,11 @@
+"""BatchL2 extension for Embedding."""
+from backpack.core.derivatives.embedding import EmbeddingDerivatives
+from backpack.extensions.firstorder.batch_l2_grad.batch_l2_base import BatchL2Base
+
+
+class BatchL2Embedding(BatchL2Base):
+    """BatchL2 extension for Embedding."""
+
+    def __init__(self):
+        """Initialization."""
+        super().__init__(derivatives=EmbeddingDerivatives(), params=["weight"])

--- a/backpack/extensions/firstorder/gradient/embedding.py
+++ b/backpack/extensions/firstorder/gradient/embedding.py
@@ -1,0 +1,11 @@
+"""Gradient extension for Embedding."""
+from backpack.core.derivatives.embedding import EmbeddingDerivatives
+from backpack.extensions.firstorder.gradient.base import GradBaseModule
+
+
+class GradEmbedding(GradBaseModule):
+    """Gradient extension for Embedding."""
+
+    def __init__(self):
+        """Initialization."""
+        super().__init__(derivatives=EmbeddingDerivatives(), params=["weight"])

--- a/backpack/extensions/firstorder/sum_grad_squared/__init__.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/__init__.py
@@ -14,6 +14,7 @@ from torch.nn import (
     ConvTranspose1d,
     ConvTranspose2d,
     ConvTranspose3d,
+    Embedding,
     Linear,
 )
 
@@ -27,6 +28,7 @@ from . import (
     convtranspose1d,
     convtranspose2d,
     convtranspose3d,
+    embedding,
     linear,
     rnn,
 )
@@ -69,5 +71,6 @@ class SumGradSquared(FirstOrderBackpropExtension):
                 BatchNorm1d: batchnorm_nd.SGSBatchNormNd(),
                 BatchNorm2d: batchnorm_nd.SGSBatchNormNd(),
                 BatchNorm3d: batchnorm_nd.SGSBatchNormNd(),
+                Embedding: embedding.SGSEmbedding(),
             },
         )

--- a/backpack/extensions/firstorder/sum_grad_squared/embedding.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/embedding.py
@@ -1,0 +1,11 @@
+"""SGS extension for Embedding."""
+from backpack.core.derivatives.embedding import EmbeddingDerivatives
+from backpack.extensions.firstorder.sum_grad_squared.sgs_base import SGSBase
+
+
+class SGSEmbedding(SGSBase):
+    """SGS extension for Embedding."""
+
+    def __init__(self):
+        """Initialization."""
+        super().__init__(derivatives=EmbeddingDerivatives(), params=["weight"])

--- a/backpack/extensions/firstorder/variance/__init__.py
+++ b/backpack/extensions/firstorder/variance/__init__.py
@@ -14,6 +14,7 @@ from torch.nn import (
     ConvTranspose1d,
     ConvTranspose2d,
     ConvTranspose3d,
+    Embedding,
     Linear,
 )
 
@@ -27,6 +28,7 @@ from . import (
     convtranspose1d,
     convtranspose2d,
     convtranspose3d,
+    embedding,
     linear,
     rnn,
 )
@@ -69,5 +71,6 @@ class Variance(FirstOrderBackpropExtension):
                 BatchNorm1d: batchnorm_nd.VarianceBatchNormNd(),
                 BatchNorm2d: batchnorm_nd.VarianceBatchNormNd(),
                 BatchNorm3d: batchnorm_nd.VarianceBatchNormNd(),
+                Embedding: embedding.VarianceEmbedding(),
             },
         )

--- a/backpack/extensions/firstorder/variance/embedding.py
+++ b/backpack/extensions/firstorder/variance/embedding.py
@@ -1,0 +1,16 @@
+"""Variance extension for Embedding."""
+from backpack.extensions.firstorder.gradient.embedding import GradEmbedding
+from backpack.extensions.firstorder.sum_grad_squared.embedding import SGSEmbedding
+from backpack.extensions.firstorder.variance.variance_base import VarianceBaseModule
+
+
+class VarianceEmbedding(VarianceBaseModule):
+    """Variance extension for Embedding."""
+
+    def __init__(self):
+        """Initialization."""
+        super().__init__(
+            grad_extension=GradEmbedding(),
+            sgs_extension=SGSEmbedding(),
+            params=["weight"],
+        )

--- a/backpack/extensions/secondorder/diag_ggn/__init__.py
+++ b/backpack/extensions/secondorder/diag_ggn/__init__.py
@@ -31,6 +31,7 @@ from torch.nn import (
     ConvTranspose3d,
     CrossEntropyLoss,
     Dropout,
+    Embedding,
     Flatten,
     Identity,
     LeakyReLU,
@@ -64,6 +65,7 @@ from . import (
     convtranspose3d,
     custom_module,
     dropout,
+    embedding,
     flatten,
     linear,
     losses,
@@ -141,6 +143,7 @@ class DiagGGN(SecondOrderBackpropExtension):
                 BatchNorm1d: batchnorm_nd.DiagGGNBatchNormNd(),
                 BatchNorm2d: batchnorm_nd.DiagGGNBatchNormNd(),
                 BatchNorm3d: batchnorm_nd.DiagGGNBatchNormNd(),
+                Embedding: embedding.DiagGGNEmbedding(),
             },
         )
 
@@ -264,6 +267,7 @@ class BatchDiagGGN(SecondOrderBackpropExtension):
                 BatchNorm1d: batchnorm_nd.BatchDiagGGNBatchNormNd(),
                 BatchNorm2d: batchnorm_nd.BatchDiagGGNBatchNormNd(),
                 BatchNorm3d: batchnorm_nd.BatchDiagGGNBatchNormNd(),
+                Embedding: embedding.BatchDiagGGNEmbedding(),
             },
         )
 

--- a/backpack/extensions/secondorder/diag_ggn/embedding.py
+++ b/backpack/extensions/secondorder/diag_ggn/embedding.py
@@ -1,0 +1,23 @@
+"""DiagGGN extension for Embedding."""
+from backpack.core.derivatives.embedding import EmbeddingDerivatives
+from backpack.extensions.secondorder.diag_ggn.diag_ggn_base import DiagGGNBaseModule
+
+
+class DiagGGNEmbedding(DiagGGNBaseModule):
+    """DiagGGN extension of Embedding."""
+
+    def __init__(self):
+        """Initialize."""
+        super().__init__(
+            derivatives=EmbeddingDerivatives(), params=["weight"], sum_batch=True
+        )
+
+
+class BatchDiagGGNEmbedding(DiagGGNBaseModule):
+    """DiagGGN extension of Embedding."""
+
+    def __init__(self):
+        """Initialize."""
+        super().__init__(
+            derivatives=EmbeddingDerivatives(), params=["weight"], sum_batch=False
+        )

--- a/backpack/extensions/secondorder/diag_ggn/losses.py
+++ b/backpack/extensions/secondorder/diag_ggn/losses.py
@@ -9,7 +9,6 @@ from backpack.extensions.secondorder.hbp import LossHessianStrategy
 class DiagGGNLoss(DiagGGNBaseModule):
     def backpropagate(self, ext, module, grad_inp, grad_out, backproped):
         hess_func = self.make_loss_hessian_func(ext)
-
         return hess_func(module, grad_inp, grad_out)
 
     def make_loss_hessian_func(self, ext):
@@ -21,7 +20,6 @@ class DiagGGNLoss(DiagGGNBaseModule):
         elif loss_hessian_strategy == LossHessianStrategy.SAMPLING:
             mc_samples = ext.get_num_mc_samples()
             return partial(self.derivatives.sqrt_hessian_sampled, mc_samples=mc_samples)
-
         else:
             raise ValueError(
                 "Unknown hessian strategy {}".format(loss_hessian_strategy)

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -13,6 +13,7 @@ backpack/core/derivatives/lstm.py
 backpack/core/derivatives/linear.py
 backpack/core/derivatives/adaptive_avg_pool_nd.py
 backpack/core/derivatives/batchnorm_nd.py
+backpack/core/derivatives/crossentropyloss.py
 backpack/core/derivatives/scale_module.py
 backpack/core/derivatives/sum_module.py
 

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -14,6 +14,7 @@ backpack/core/derivatives/linear.py
 backpack/core/derivatives/adaptive_avg_pool_nd.py
 backpack/core/derivatives/batchnorm_nd.py
 backpack/core/derivatives/crossentropyloss.py
+backpack/core/derivatives/embedding.py
 backpack/core/derivatives/scale_module.py
 backpack/core/derivatives/sum_module.py
 
@@ -27,18 +28,22 @@ backpack/extensions/firstorder/gradient/base.py
 backpack/extensions/firstorder/gradient/rnn.py
 backpack/extensions/firstorder/gradient/__init__.py
 backpack/extensions/firstorder/gradient/batchnorm_nd.py
+backpack/extensions/firstorder/gradient/embedding.py
 backpack/extensions/firstorder/batch_grad/batch_grad_base.py
 backpack/extensions/firstorder/batch_grad/rnn.py
 backpack/extensions/firstorder/batch_grad/__init__.py
 backpack/extensions/firstorder/batch_grad/batchnorm_nd.py
+backpack/extensions/firstorder/batch_grad/embedding.py
 backpack/extensions/firstorder/variance/variance_base.py
 backpack/extensions/firstorder/variance/rnn.py
 backpack/extensions/firstorder/variance/__init__.py
 backpack/extensions/firstorder/variance/batchnorm_nd.py
+backpack/extensions/firstorder/variance/embedding.py
 backpack/extensions/firstorder/sum_grad_squared/sgs_base.py
 backpack/extensions/firstorder/sum_grad_squared/rnn.py
 backpack/extensions/firstorder/sum_grad_squared/__init__.py
 backpack/extensions/firstorder/sum_grad_squared/batchnorm_nd.py
+backpack/extensions/firstorder/sum_grad_squared/embedding.py
 backpack/extensions/firstorder/batch_l2_grad/
 backpack/extensions/secondorder/__init__.py
 backpack/extensions/secondorder/diag_ggn/__init__.py
@@ -47,6 +52,7 @@ backpack/extensions/secondorder/diag_ggn/rnn.py
 backpack/extensions/secondorder/diag_ggn/permute.py
 backpack/extensions/secondorder/diag_ggn/batchnorm_nd.py
 backpack/extensions/secondorder/diag_ggn/adaptive_avg_pool_nd.py
+backpack/extensions/secondorder/diag_ggn/embedding.py
 backpack/extensions/secondorder/diag_ggn/custom_module.py
 backpack/extensions/secondorder/diag_hessian/__init__.py
 backpack/extensions/secondorder/diag_hessian/conv1d.py
@@ -91,6 +97,7 @@ test/core/derivatives/permute_settings.py
 test/core/derivatives/lstm_settings.py
 test/core/derivatives/pooling_adaptive_settings.py
 test/core/derivatives/batch_norm_settings.py
+test/core/derivatives/embedding_settings.py
 test/core/derivatives/scale_module_settings.py
 test/utils/evaluation_mode.py
 test/utils/skip_test.py

--- a/test/converter/converter_cases.py
+++ b/test/converter/converter_cases.py
@@ -225,6 +225,9 @@ class _TolstoiCharRNN(ConverterModule):
     def input_fn(self) -> Tensor:
         return randint(0, self.vocab_size, (8, 15))
 
+    def loss_fn(self) -> Module:
+        return CrossEntropyLoss()
+
 
 CONVERTER_MODULES += [
     _ResNet18,

--- a/test/converter/test_converter.py
+++ b/test/converter/test_converter.py
@@ -34,7 +34,6 @@ def model_and_input(request) -> Tuple[Module, Tensor, Module]:
     skip_pytorch_below_1_9_0()
     model: ConverterModule = request.param()
     inputs: Tensor = model.input_fn()
-    inputs.requires_grad = True
     loss_fn: Module = model.loss_fn()
     yield model, inputs, loss_fn
     del model, inputs, loss_fn
@@ -53,6 +52,7 @@ def test_network_diag_ggn(model_and_input):
         model_and_input: module to test
     """
     model_original, x, loss_fn = model_and_input
+    model_original = model_original.eval()
     output_compare = model_original(x)
     if isinstance(loss_fn, MSELoss):
         y = rand_like(output_compare)
@@ -85,4 +85,4 @@ def test_network_diag_ggn(model_and_input):
     )
 
     for idx, element in zip(idx_to_compare, diag_ggn_exact_to_compare):
-        assert allclose(element, diag_ggn_exact_vector[idx])
+        assert allclose(element, diag_ggn_exact_vector[idx], atol=1e-5)

--- a/test/converter/test_converter.py
+++ b/test/converter/test_converter.py
@@ -7,6 +7,7 @@ from test.converter.converter_cases import CONVERTER_MODULES, ConverterModule
 from test.utils.skip_test import skip_pytorch_below_1_9_0
 from typing import Tuple
 
+import torch
 from pytest import fixture
 from torch import Tensor, allclose, cat, int32, linspace, manual_seed, rand_like
 from torch.nn import Module, MSELoss
@@ -20,22 +21,23 @@ from backpack.utils.examples import autograd_diag_ggn_exact
     params=CONVERTER_MODULES,
     ids=[str(model_class) for model_class in CONVERTER_MODULES],
 )
-def model_and_input(request) -> Tuple[Module, Tensor]:
+def model_and_input(request) -> Tuple[Module, Tensor, Module]:
     """Yield ResNet model and an input to it.
 
     Args:
         request: pytest request
 
     Yields:
-        model and input
+        model and input and loss function
     """
     manual_seed(0)
     skip_pytorch_below_1_9_0()
     model: ConverterModule = request.param()
     inputs: Tensor = model.input_fn()
     inputs.requires_grad = True
-    yield model, inputs
-    del model, inputs
+    loss_fn: Module = model.loss_fn()
+    yield model, inputs, loss_fn
+    del model, inputs, loss_fn
 
 
 def test_network_diag_ggn(model_and_input):
@@ -50,15 +52,22 @@ def test_network_diag_ggn(model_and_input):
     Args:
         model_and_input: module to test
     """
-    model_original, x = model_and_input
+    model_original, x, loss_fn = model_and_input
     output_compare = model_original(x)
-    y = rand_like(output_compare)
+    if isinstance(loss_fn, MSELoss):
+        y = rand_like(output_compare)
+    else:
+        y = torch.randint(
+            0,
+            output_compare.shape[1],
+            (output_compare.shape[0], *output_compare.shape[2:]),
+        )
 
     num_params = sum(p.numel() for p in model_original.parameters())
     num_to_compare = 10
     idx_to_compare = linspace(0, num_params - 1, num_to_compare, dtype=int32)
     diag_ggn_exact_to_compare = autograd_diag_ggn_exact(
-        x, y, model_original, MSELoss(), idx=idx_to_compare
+        x, y, model_original, loss_fn, idx=idx_to_compare
     )
 
     model_extended = extend(model_original, use_converter=True, debug=True)
@@ -66,7 +75,7 @@ def test_network_diag_ggn(model_and_input):
 
     assert allclose(output, output_compare)
 
-    loss = extend(MSELoss())(output, y)
+    loss = extend(loss_fn)(output, y)
 
     with backpack(DiagGGNExact()):
         loss.backward()

--- a/test/core/derivatives/__init__.py
+++ b/test/core/derivatives/__init__.py
@@ -21,6 +21,7 @@ from torch.nn import (
     ConvTranspose3d,
     CrossEntropyLoss,
     Dropout,
+    Embedding,
     Identity,
     LeakyReLU,
     Linear,
@@ -53,6 +54,7 @@ from backpack.core.derivatives.conv_transpose3d import ConvTranspose3DDerivative
 from backpack.core.derivatives.crossentropyloss import CrossEntropyLossDerivatives
 from backpack.core.derivatives.dropout import DropoutDerivatives
 from backpack.core.derivatives.elu import ELUDerivatives
+from backpack.core.derivatives.embedding import EmbeddingDerivatives
 from backpack.core.derivatives.leakyrelu import LeakyReLUDerivatives
 from backpack.core.derivatives.linear import LinearDerivatives
 from backpack.core.derivatives.logsigmoid import LogSigmoidDerivatives
@@ -108,6 +110,7 @@ derivatives_for = {
     BatchNorm1d: BatchNormNdDerivatives,
     BatchNorm2d: BatchNormNdDerivatives,
     BatchNorm3d: BatchNormNdDerivatives,
+    Embedding: EmbeddingDerivatives,
     ScaleModule: ScaleModuleDerivatives,
     ActiveIdentity: ScaleModuleDerivatives,
     Identity: ScaleModuleDerivatives,

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -469,3 +469,19 @@ def test_hessian_is_zero(no_loss_problem: DerivativesTestProblem) -> None:
         )
     else:
         assert backpack_res == autograd_res
+
+
+@mark.parametrize("problem", LOSS_PROBLEMS, ids=LOSS_IDS)
+def test_make_hessian_mat_prod(problem: DerivativesTestProblem) -> None:
+    """Test hessian_mat_prod.
+
+    Args:
+        problem: test problem
+    """
+    problem.set_up()
+    mat = rand(4, *problem.input_shape, device=problem.device)
+
+    autograd_res = AutogradDerivatives(problem).hessian_mat_prod(mat)
+    backpack_res = BackpackDerivatives(problem).hessian_mat_prod(mat)
+
+    check_sizes_and_values(backpack_res, autograd_res)

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -9,6 +9,7 @@
 from contextlib import nullcontext
 from test.automated_test import check_sizes_and_values
 from test.core.derivatives.batch_norm_settings import BATCH_NORM_SETTINGS
+from test.core.derivatives.embedding_settings import EMBEDDING_SETTINGS
 from test.core.derivatives.implementation.autograd import AutogradDerivatives
 from test.core.derivatives.implementation.backpack import BackpackDerivatives
 from test.core.derivatives.loss_settings import LOSS_FAIL_SETTINGS
@@ -54,6 +55,9 @@ PERMUTE_IDS = [problem.make_id() for problem in PERMUTE_PROBLEMS]
 
 BATCH_NORM_PROBLEMS = make_test_problems(BATCH_NORM_SETTINGS)
 BATCH_NORM_IDS = [problem.make_id() for problem in BATCH_NORM_PROBLEMS]
+
+EMBEDDING_PROBLEMS = make_test_problems(EMBEDDING_SETTINGS)
+EMBEDDING_IDS = [problem.make_id() for problem in EMBEDDING_PROBLEMS]
 
 SCALE_MODULE_PROBLEMS = make_test_problems(SCALE_MODULE_SETTINGS)
 SCALE_MODULE_IDS = [problem.make_id() for problem in SCALE_MODULE_PROBLEMS]
@@ -394,7 +398,8 @@ def test_ea_jac_t_mat_jac_prod(problem: DerivativesTestProblem, request) -> None
 
 
 @fixture(
-    params=PROBLEMS + BATCH_NORM_PROBLEMS + RNN_PROBLEMS, ids=lambda p: p.make_id()
+    params=PROBLEMS + BATCH_NORM_PROBLEMS + RNN_PROBLEMS + EMBEDDING_PROBLEMS,
+    ids=lambda p: p.make_id(),
 )
 def problem(request) -> DerivativesTestProblem:
     """Set seed, create tested layer and data. Finally clean up.

--- a/test/core/derivatives/embedding_settings.py
+++ b/test/core/derivatives/embedding_settings.py
@@ -1,0 +1,14 @@
+"""Settings for testing derivatives of Embedding."""
+from torch import randint
+from torch.nn import Embedding
+
+EMBEDDING_SETTINGS = [
+    {
+        "module_fn": lambda: Embedding(3, 5),
+        "input_fn": lambda: randint(0, 3, (4,)),
+    },
+    {
+        "module_fn": lambda: Embedding(5, 7),
+        "input_fn": lambda: randint(0, 5, (8, 3, 3)),
+    },
+]

--- a/test/core/derivatives/implementation/base.py
+++ b/test/core/derivatives/implementation/base.py
@@ -117,3 +117,15 @@ class DerivativesImplementation(ABC):
             `True`, if Hessian is zero, else `False`.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def hessian_mat_prod(self, mat: Tensor) -> Tensor:
+        """Product of hessian with matrix mat.
+
+        Args:
+            mat: matrix to multiply
+
+        Returns:
+            product
+        """
+        raise NotImplementedError

--- a/test/core/derivatives/loss_settings.py
+++ b/test/core/derivatives/loss_settings.py
@@ -3,7 +3,7 @@
 Required entries:
     "module_fn" (callable): Contains a model constructed from `torch.nn` layers
     "input_fn" (callable): Used for specifying input function
-    "target_fn" (callable): Fetches the groundtruth/target classes 
+    "target_fn" (callable): Fetches the groundtruth/target classes
                             of regression/classification task
     "loss_function_fn" (callable): Loss function used in the model
 
@@ -28,7 +28,7 @@ LOSS_SETTINGS = []
 example = {
     "module_fn": lambda: torch.nn.CrossEntropyLoss(reduction="mean"),
     "input_fn": lambda: torch.rand(size=(2, 4)),
-    "target_fn": lambda: classification_targets(size=(2,), num_classes=2),
+    "target_fn": lambda: classification_targets(size=(2,), num_classes=4),
     "device": [torch.device("cpu")],  # optional
     "seed": 0,  # optional
     "id_prefix": "loss-example",  # optional
@@ -39,13 +39,23 @@ LOSS_SETTINGS.append(example)
 LOSS_SETTINGS += [
     {
         "module_fn": lambda: torch.nn.CrossEntropyLoss(reduction="mean"),
+        "input_fn": lambda: torch.rand(size=(2, 4, 3)),
+        "target_fn": lambda: classification_targets(size=(2, 3), num_classes=4),
+    },
+    {
+        "module_fn": lambda: torch.nn.CrossEntropyLoss(reduction="mean"),
+        "input_fn": lambda: torch.rand(size=(3, 4, 3, 2)),
+        "target_fn": lambda: classification_targets(size=(3, 3, 2), num_classes=4),
+    },
+    {
+        "module_fn": lambda: torch.nn.CrossEntropyLoss(reduction="mean"),
         "input_fn": lambda: torch.rand(size=(2, 4)),
-        "target_fn": lambda: classification_targets(size=(2,), num_classes=2),
+        "target_fn": lambda: classification_targets(size=(2,), num_classes=4),
     },
     {
         "module_fn": lambda: torch.nn.CrossEntropyLoss(reduction="sum"),
         "input_fn": lambda: torch.rand(size=(8, 4)),
-        "target_fn": lambda: classification_targets(size=(8,), num_classes=2),
+        "target_fn": lambda: classification_targets(size=(8,), num_classes=4),
     },
     {
         "module_fn": lambda: torch.nn.CrossEntropyLoss(reduction="none"),

--- a/test/core/derivatives/problem.py
+++ b/test/core/derivatives/problem.py
@@ -5,7 +5,7 @@ from test.core.derivatives.utils import derivative_cls_for, get_available_device
 from typing import Dict, List, Tuple
 
 import torch
-from torch import Tensor
+from torch import Tensor, long
 
 from backpack import extend
 from backpack.utils.module_classification import is_loss
@@ -151,7 +151,7 @@ class DerivativesTestProblem:
             batch_axis_in = get_batch_axis(self.module, "input0")
             input = subsample(input, dim=batch_axis_in, subsampling=subsampling)
 
-        if input_requires_grad:
+        if input_requires_grad and input.dtype is not long:
             input.requires_grad = True
 
         if self.is_loss():

--- a/test/core/derivatives/utils.py
+++ b/test/core/derivatives/utils.py
@@ -37,11 +37,11 @@ def derivative_cls_for(module_cls: Type[Module]) -> Type[BaseDerivatives]:
     """
     try:
         return derivatives_for[module_cls]
-    except KeyError:
+    except KeyError as e:
         raise KeyError(
-            "No derivative available for {}".format(module_cls)
-            + "Known mappings:\n{}".format(derivatives_for)
-        )
+            f"No derivative available for {module_cls}."
+            + f"Known mappings:\n{derivatives_for}"
+        ) from e
 
 
 def classification_targets(size: Tuple[int, ...], num_classes: int) -> Tensor:

--- a/test/extensions/firstorder/firstorder_settings.py
+++ b/test/extensions/firstorder/firstorder_settings.py
@@ -22,7 +22,7 @@ from test.core.derivatives.utils import classification_targets, regression_targe
 from test.extensions.automated_settings import make_simple_cnn_setting
 from test.utils.evaluation_mode import initialize_training_false_recursive
 
-from torch import device, rand
+from torch import device, rand, randint
 from torch.nn import (
     LSTM,
     RNN,
@@ -36,6 +36,7 @@ from torch.nn import (
     ConvTranspose2d,
     ConvTranspose3d,
     CrossEntropyLoss,
+    Embedding,
     Flatten,
     Linear,
     MSELoss,
@@ -297,6 +298,30 @@ FIRSTORDER_SETTINGS += [
         "target_fn": lambda: classification_targets((4,), 20),
     },
 ]
+###############################################################################
+#                         test setting: Embedding                             #
+###############################################################################
+FIRSTORDER_SETTINGS += [
+    {
+        "input_fn": lambda: randint(0, 5, (6,)),
+        "module_fn": lambda: Sequential(
+            Embedding(5, 3),
+            Linear(3, 4),
+        ),
+        "loss_function_fn": lambda: CrossEntropyLoss(reduction="mean"),
+        "target_fn": lambda: classification_targets((6,), 4),
+    },
+    {
+        "input_fn": lambda: randint(0, 3, (4, 2, 2)),
+        "module_fn": lambda: Sequential(
+            Embedding(3, 5),
+            Flatten(),
+        ),
+        "loss_function_fn": lambda: CrossEntropyLoss(reduction="mean"),
+        "target_fn": lambda: classification_targets((4,), 2 * 5),
+    },
+]
+
 ###############################################################################
 #                     test setting: torchvision resnet                        #
 ###############################################################################

--- a/test/extensions/secondorder/diag_ggn/diag_ggn_settings.py
+++ b/test/extensions/secondorder/diag_ggn/diag_ggn_settings.py
@@ -14,7 +14,7 @@ from test.core.derivatives.utils import classification_targets, regression_targe
 from test.extensions.secondorder.secondorder_settings import SECONDORDER_SETTINGS
 from test.utils.evaluation_mode import initialize_training_false_recursive
 
-from torch import rand
+from torch import rand, randint
 from torch.nn import (
     LSTM,
     RNN,
@@ -26,6 +26,7 @@ from torch.nn import (
     BatchNorm3d,
     Conv2d,
     CrossEntropyLoss,
+    Embedding,
     Flatten,
     Linear,
     MaxPool2d,
@@ -160,6 +161,32 @@ LOCAL_SETTINGS += [
     },
 ]
 ###############################################################################
+#                               Embedding                                     #
+###############################################################################
+LOCAL_SETTINGS += [
+    {
+        "input_fn": lambda: randint(0, 5, (6,)),
+        "module_fn": lambda: Sequential(
+            Embedding(5, 3),
+            Linear(3, 4),
+        ),
+        "loss_function_fn": lambda: CrossEntropyLoss(reduction="mean"),
+        "target_fn": lambda: classification_targets((6,), 4),
+    },
+    {
+        "input_fn": lambda: randint(0, 3, (3, 2, 2)),
+        "module_fn": lambda: Sequential(
+            Embedding(3, 2),
+            Flatten(),
+        ),
+        "loss_function_fn": lambda: CrossEntropyLoss(reduction="mean"),
+        "target_fn": lambda: classification_targets((3,), 2 * 2),
+        "seed": 1,
+    },
+]
+
+
+###############################################################################
 #                               Branched models                               #
 ###############################################################################
 LOCAL_SETTINGS += [
@@ -236,6 +263,7 @@ LOCAL_SETTINGS += [
         "id_prefix": "nested-branching-convolution",
     },
 ]
+
 ###############################################################################
 #                      Branched models - converter                            #
 ###############################################################################
@@ -256,4 +284,5 @@ if CONVERTER_AVAILABLE:
             "id_prefix": "ResNet2",
         },
     ]
+
 DiagGGN_SETTINGS = SHARED_SETTINGS + LOCAL_SETTINGS

--- a/test/extensions/secondorder/diag_ggn/diag_ggn_settings.py
+++ b/test/extensions/secondorder/diag_ggn/diag_ggn_settings.py
@@ -73,6 +73,18 @@ LOCAL_SETTINGS += [
         "loss_function_fn": lambda: CrossEntropyLoss(),
         "target_fn": lambda: classification_targets((4,), 4 * 3),
     },
+    {
+        "input_fn": lambda: rand(5, 8, 6),  # TODO (8, 5, 6)
+        "module_fn": lambda: Sequential(
+            RNN(input_size=6, hidden_size=3),  # TODO batch_first=True
+            ReduceTuple(index=0),
+            Permute(1, 0, 2, batch_axis=1),  # TODO remove
+            Linear(3, 3),
+            Permute(0, 2, 1, batch_axis=0),
+        ),
+        "loss_function_fn": lambda: CrossEntropyLoss(),
+        "target_fn": lambda: classification_targets((8, 5), 3),
+    },
 ]
 ##################################################################
 #                AdaptiveAvgPool settings                        #

--- a/test/extensions/secondorder/secondorder_settings.py
+++ b/test/extensions/secondorder/secondorder_settings.py
@@ -301,3 +301,16 @@ LINEAR_ADDITIONAL_DIMENSIONS_SETTINGS = [
 ]
 
 SECONDORDER_SETTINGS += LINEAR_ADDITIONAL_DIMENSIONS_SETTINGS
+
+###############################################################################
+#                         test setting: CrossEntropyLoss                      #
+###############################################################################
+SECONDORDER_SETTINGS += [
+    {
+        "input_fn": lambda: rand(3, 4, 2, 3, 5),
+        "module_fn": lambda: Sequential(Linear(5, 3), ReLU(), Linear(3, 2)),
+        "loss_function_fn": lambda: CrossEntropyLoss(reduction="sum"),
+        "target_fn": lambda: classification_targets((3, 2, 3, 2), 4),
+        "id_prefix": "multi-d-CrossEntropyLoss",
+    },
+]

--- a/test/test_second_order_warnings.py
+++ b/test/test_second_order_warnings.py
@@ -5,6 +5,8 @@ Failure cases include
 - using unsupported parameters of the loss
 """
 
+from test.core.derivatives.utils import classification_targets
+
 import pytest
 import torch
 from torch.nn import CrossEntropyLoss, MSELoss
@@ -29,15 +31,10 @@ ext_2nd_order_name = [
 ]
 
 
-def classification_targets(N, num_classes):
-    """Create random targets for classes 0, ..., `num_classes - 1`."""
-    return torch.randint(size=(N,), low=0, high=num_classes)
-
-
 def dummy_cross_entropy(N=5):
     y_pred = torch.rand((N, 2))
     y_pred.requires_grad = True
-    y = classification_targets(N, 2)
+    y = classification_targets((N,), 2)
     loss_module = extend(CrossEntropyLoss())
     return loss_module(y_pred, y)
 


### PR DESCRIPTION
This PR expands the RNN support with the converter. As a result, the Tolstoi Char RNN from DeepOBS can be supported.
Changes:
- backpack/custom_module/graph_utils.py
- test/converter/converter_cases.py (added permute and tolstoi test case)
- test/converter/test_converter.py (adjusted test to allow multi-d-crossentropy)