### PR TITLE
[FIX] Use batch size 1 in KFAC ResNet tests

### DIFF
--- a/test/extensions/secondorder/hbp/kfac_settings.py
+++ b/test/extensions/secondorder/hbp/kfac_settings.py
@@ -9,7 +9,6 @@ from test.extensions.secondorder.secondorder_settings import (
 from torch import rand
 from torch.nn import (
     CrossEntropyLoss,
-    Flatten,
     Identity,
     Linear,
     MSELoss,

--- a/test/extensions/secondorder/hbp/kfac_settings.py
+++ b/test/extensions/secondorder/hbp/kfac_settings.py
@@ -31,15 +31,12 @@ NOT_SUPPORTED_SETTINGS = SHARED_NOT_SUPPORTED_SETTINGS + LOCAL_NOT_SUPPORTED_SET
 BATCH_SIZE_1_SETTINGS = [
     {
         "input_fn": lambda: rand(1, 7),
-        "module_fn": lambda: Sequential(
-            Linear(7, 3), ReLU(), Flatten(start_dim=1, end_dim=-1), Linear(3, 1)
-        ),
+        "module_fn": lambda: Sequential(Linear(7, 3), ReLU(), Linear(3, 1)),
         "loss_function_fn": lambda: MSELoss(reduction="mean"),
         "target_fn": lambda: regression_targets((1, 1)),
-        "id_prefix": "one-additional",
     },
     {
-        "input_fn": lambda: rand(3, 10),
+        "input_fn": lambda: rand(1, 10),
         "module_fn": lambda: Sequential(
             Linear(10, 5),
             ReLU(),
@@ -53,11 +50,11 @@ BATCH_SIZE_1_SETTINGS = [
             Linear(5, 4),
         ),
         "loss_function_fn": lambda: CrossEntropyLoss(),
-        "target_fn": lambda: classification_targets((3,), 4),
+        "target_fn": lambda: classification_targets((1,), 4),
         "id_prefix": "branching-linear",
     },
     {
-        "input_fn": lambda: rand(3, 10),
+        "input_fn": lambda: rand(1, 10),
         "module_fn": lambda: Sequential(
             Linear(10, 5),
             ReLU(),
@@ -71,7 +68,7 @@ BATCH_SIZE_1_SETTINGS = [
             Linear(5, 4),
         ),
         "loss_function_fn": lambda: CrossEntropyLoss(),
-        "target_fn": lambda: classification_targets((3,), 4),
+        "target_fn": lambda: classification_targets((1,), 4),
         "id_prefix": "branching-scalar",
     },
 ]


### PR DESCRIPTION
By accident, they used batch size 3. Surprisingly, this was not caught by the test. The KFAC approximation was accurate enough for three samples.