### PR TITLE
[FIX] Copy `_grad_input_padding` from `torch==1.9`, update test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        pytorch-version: [1.9.0, 1.9.1]
+        pytorch-version: [1.12.1, 1.13]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/backpack/core/derivatives/basederivatives.py
+++ b/backpack/core/derivatives/basederivatives.py
@@ -9,7 +9,7 @@ from torch.nn import Module
 from backpack.core.derivatives import shape_check
 
 
-class BaseDerivatives(ABC):
+class BaseDerivatives(ABC):  # noqa: B024
     """First- and second-order partial derivatives of unparameterized module.
 
     Note:

--- a/backpack/core/derivatives/conv_transposend.py
+++ b/backpack/core/derivatives/conv_transposend.py
@@ -5,10 +5,9 @@ from einops import rearrange
 from numpy import prod
 from torch import Tensor, einsum
 from torch.nn import ConvTranspose1d, ConvTranspose2d, ConvTranspose3d, Module
-from torch.nn.grad import _grad_input_padding
 
 from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
-from backpack.utils.conv import get_conv_function
+from backpack.utils.conv import _grad_input_padding, get_conv_function
 from backpack.utils.conv_transpose import (
     get_conv_transpose_function,
     unfold_by_conv_transpose,

--- a/backpack/core/derivatives/convnd.py
+++ b/backpack/core/derivatives/convnd.py
@@ -5,10 +5,9 @@ from einops import rearrange, reduce
 from numpy import prod
 from torch import Tensor, einsum
 from torch.nn import Conv1d, Conv2d, Conv3d, Module
-from torch.nn.grad import _grad_input_padding
 
 from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
-from backpack.utils.conv import get_conv_function, unfold_by_conv
+from backpack.utils.conv import _grad_input_padding, get_conv_function, unfold_by_conv
 from backpack.utils.conv_transpose import get_conv_transpose_function
 from backpack.utils.subsampling import subsample
 

--- a/backpack/utils/conv.py
+++ b/backpack/utils/conv.py
@@ -1,4 +1,5 @@
 from typing import Callable, Type, Union
+from warnings import warn
 
 import torch
 from einops import rearrange
@@ -164,3 +165,48 @@ def unfold_by_conv(input, module):
     )
 
     return unfold.reshape(N, C_in * kernel_size_numel, -1)
+
+
+def _grad_input_padding(
+    grad_output, input_size, stride, padding, kernel_size, dilation=None
+):
+    """Determine padding for the VJP of convolution.
+
+    Note:
+        This function was copied from the PyTorch repository (version 1.9).
+        It was removed between torch 1.12.1 and torch 1.13.
+    """
+    if dilation is None:
+        # For backward compatibility
+        warn(
+            "_grad_input_padding 'dilation' argument not provided. Default of 1 is used."
+        )
+        dilation = [1] * len(stride)
+
+    input_size = list(input_size)
+    k = grad_output.dim() - 2
+
+    if len(input_size) == k + 2:
+        input_size = input_size[-k:]
+    if len(input_size) != k:
+        raise ValueError(f"input_size must have {k+2} elements (got {len(input_size)})")
+
+    def dim_size(d):
+        return (
+            (grad_output.size(d + 2) - 1) * stride[d]
+            - 2 * padding[d]
+            + 1
+            + dilation[d] * (kernel_size[d] - 1)
+        )
+
+    min_sizes = [dim_size(d) for d in range(k)]
+    max_sizes = [min_sizes[d] + stride[d] - 1 for d in range(k)]
+    for size, min_size, max_size in zip(input_size, min_sizes, max_sizes):
+        if size < min_size or size > max_size:
+            raise ValueError(
+                f"requested an input grad size of {input_size}, but valid sizes range "
+                f"from {min_sizes} to {max_sizes} (for a grad_output of "
+                f"{grad_output.size()[2:]})"
+            )
+
+    return tuple(input_size[d] - min_sizes[d] for d in range(k))


### PR DESCRIPTION
The function was removed between torch 1.12.1 and torch 1.13. Reintroducing it should fix
https://github.com/f-dangel/backpack/issues/272.