### PR TITLE
[REF] Use `unfoldNd` package for input unfolding of convolutions

### DIFF
--- a/backpack/utils/conv.py
+++ b/backpack/utils/conv.py
@@ -137,7 +137,17 @@ def extract_bias_diagonal(module, S, sum_batch=True):
 def unfold_by_conv(
     input: torch.Tensor, module: Union[Conv1d, Conv2d, Conv3d]
 ) -> torch.Tensor:
-    """Return the unfolded input using convolution."""
+    """Return the unfolded input using convolution.
+
+    Args:
+        input: Convolution layer input.
+        module: Convolution layer.
+
+    Returns:
+        Unfolded input. For a 2d convolution with input of shape `[N, C_in, *, *]`
+        and a kernel of shape `[_, _, K_H, K_W]`, this tensor has shape
+        `[N, C_in * K_H * K_W, L]` where `L` is the output's number of patches.
+    """
     return unfoldNd(
         input,
         module.kernel_size,

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     torch >= 1.9.0, < 1.13.0
     torchvision >= 0.7.0, < 1.0.0
     einops >= 0.3.0, < 1.0.0
+    unfoldNd >= 0.1.0, < 1.0.0
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.7
 


### PR DESCRIPTION
Long ago, I extracted the `im2col` code from BackPACK's convolution utilities into a [separate package](https://github.com/f-dangel/unfoldNd), where it is documented, tested, and benchmarked in more detail. This PR removes code from the BackPACK repository and relies on the extracted package instead.