### PR TITLE
[DOC] Fully document `HBPConv2d`

### DIFF
--- a/backpack/extensions/secondorder/hbp/conv2d.py
+++ b/backpack/extensions/secondorder/hbp/conv2d.py
@@ -52,10 +52,10 @@ class HBPConv2d(HBPBaseModule):
             g_out: output gradient.
             backproped: Backpropagated quantity, depends on the approximation mode.
                 For KFLR/KFAC this is the MC/exact matrix square root of the GGN w.r.t.
-                the convolution output (shape `[M, N, C, H, W]`) and has shape
+                the convolution output (shape `[N, C, H, W]`) and has shape
                 `[M, N, C, H, W]` with `M` the number of MC samples or the number of
                 classes for KFAC/KFLR, respectively. For KFRA, the backpropagated
-                object approximates the batch-averaged GGN w.r.t. to the convolution
+                object approximates the batch-averaged Hessian w.r.t. to the convolution
                 output and has shape `[C * H * W, C * H * W]`.
 
         Returns:
@@ -82,8 +82,8 @@ class HBPConv2d(HBPBaseModule):
     def _factors_from_input(self, ext: HBP, module: Conv2d) -> List[Tensor]:
         """Compute the un-centered covariance of the unfolded input.
 
-        In the notation of http://proceedings.mlr.press/v48/grosse16.pdf,
-        this computes Ω from equation (23) for KFAC.
+        In the notation of https://arxiv.org/pdf/1602.01407.pdf,
+        this computes Ω from equation (32) for KFAC.
 
         Args:
             ext: HBP extension.
@@ -113,7 +113,7 @@ class HBPConv2d(HBPBaseModule):
 
         Note:
             In comparison to the KFC paper, the output differs by a factor of |Τ|.
-            This is because |Τ| * Γ is the MC/exact GGN w.r.t. the convolution's bias.
+            This is because |Τ| * Γ is the MC/exact GGN w.r.t. the convolution's bias,
             For two-dimensional convolution with output of shape `[N, C_out, H, W]`,
             |Τ| = H * W.
 
@@ -152,10 +152,10 @@ class HBPConv2d(HBPBaseModule):
             g_out: output gradient.
             backproped: Backpropagated quantity, depends on the approximation mode.
                 For KFLR/KFAC this is the MC/exact matrix square root of the GGN w.r.t.
-                the convolution output (shape `[M, N, C, H, W]`) and has shape
+                the convolution output (shape `[N, C, H, W]`) and has shape
                 `[M, N, C, H, W]` with `M` the number of MC samples or the number of
                 classes for KFAC/KFLR, respectively. For KFRA, the backpropagated
-                object approximates the batch-averaged GGN w.r.t. to the convolution
+                object approximates the batch-averaged Hessian w.r.t. the convolution
                 output and has shape `[C * H * W, C * H * W]`.
 
         Returns:

--- a/backpack/extensions/secondorder/hbp/conv2d.py
+++ b/backpack/extensions/secondorder/hbp/conv2d.py
@@ -1,4 +1,11 @@
-from torch import einsum
+"""Kronecker approximations of the Hessian for convolution layers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple
+
+from torch import Tensor, einsum
+from torch.nn import Conv2d
 
 from backpack.core.derivatives.conv2d import Conv2DDerivatives
 from backpack.extensions.secondorder.hbp.hbp_options import (
@@ -8,74 +15,209 @@ from backpack.extensions.secondorder.hbp.hbp_options import (
 from backpack.extensions.secondorder.hbp.hbpbase import HBPBaseModule
 from backpack.utils import conv as convUtils
 
+if TYPE_CHECKING:
+    from backpack.extensions.secondorder.hbp import HBP
+
 
 class HBPConv2d(HBPBaseModule):
+    """Computes Kronecker-structured Hessian approximations for convolution layers."""
+
     def __init__(self):
+        """Pass derivatives for convolution."""
         super().__init__(derivatives=Conv2DDerivatives(), params=["weight", "bias"])
 
-    def weight(self, ext, module, g_inp, g_out, backproped):
+    def weight(
+        self,
+        ext: HBP,
+        module: Conv2d,
+        g_inp: Tuple[Tensor],
+        g_out: Tuple[Tensor],
+        backproped: Tensor,
+    ) -> List[Tensor]:
+        """Compute the Kronecker factors for the weight Hessian approximation.
 
-        if module.groups != 1:
-            raise NotImplementedError(
-                f"groups ≠ 1 is not supported by {ext.__class__.__name__} "
-                + f"(got {module.groups})."
-            )
+        Note:
+            TODO The Kronecker factor computed from the backpropagated quantity
+            differs from the KFC paper (https://arxiv.org/pdf/1602.01407.pdf)
+            by a factor of |Τ| = H * W where H, W denote the spatial output
+            dimensions of the convolution. If this convention is changed to be
+            more consistent with the paper, this must be clearly communicated
+            to users as it will alter the scale of the KFAC quantity for weights of
+            convolutions in comparison to older versions.
 
+        Args:
+            ext: HBP extension.
+            module: convolution layer the backpropagation is performed on.
+            g_inp: input gradient.
+            g_out: output gradient.
+            backproped: Backpropagated quantity, depends on the approximation mode.
+                For KFLR/KFAC this is the MC/exact matrix square root of the GGN w.r.t.
+                the convolution output (shape `[M, N, C, H, W]`) and has shape
+                `[M, N, C, H, W]` with `M` the number of MC samples or the number of
+                classes for KFAC/KFLR, respectively. For KFRA, the backpropagated
+                object approximates the batch-averaged GGN w.r.t. to the convolution
+                output and has shape `[C * H * W, C * H * W]`.
+
+        Returns:
+            List of Kronecker factors whose Kronecker product approximates the weight
+            Hessian. Its length depends on the Hessian approximation. If `[A, B, C]`
+            is returned, then `A ⊗ B ⊗ C` has shape `[weights.numel(), weights.numel()]`
+            and approximates the weight Hessian.
+        """
+        self._maybe_raise_groups_not_implemented_error(ext, module)
+
+        kron_factors: List[Tensor] = []
         bp_strategy = ext.get_backprop_strategy()
 
-        if BackpropStrategy.is_batch_average(bp_strategy):
-            return self._weight_for_batch_average(ext, module, backproped)
+        # TODO Find a setting in which this corresponds to an autodiff quantity, test
+        if BackpropStrategy.is_batch_average(bp_strategy):  # KFRA
+            kron_factors.append(self._factor_from_batch_average(module, backproped))
 
-        elif BackpropStrategy.is_sqrt(bp_strategy):
-            return self._weight_for_sqrt(ext, module, backproped)
+        elif BackpropStrategy.is_sqrt(bp_strategy):  # KFLR, KFAC
+            kron_factors.append(self._factor_from_sqrt(module, backproped))
 
-    # TODO: Require tests
-    def _weight_for_batch_average(self, ext, module, backproped):
-        kron_factors = [self._factor_from_batch_average(module, backproped)]
         kron_factors += self._factors_from_input(ext, module)
         return kron_factors
 
-    def _weight_for_sqrt(self, ext, module, backproped):
-        kron_factors = [self._factor_from_sqrt(module, backproped)]
-        kron_factors += self._factors_from_input(ext, module)
-        return kron_factors
+    def _factors_from_input(self, ext: HBP, module: Conv2d) -> List[Tensor]:
+        """Compute the un-centered covariance of the unfolded input.
 
-    def _factors_from_input(self, ext, module):
-        X = convUtils.unfold_input(module, module.input0)
-        batch = X.size(0)
+        In the notation of http://proceedings.mlr.press/v48/grosse16.pdf,
+        this computes Ω from equation (23) for KFAC.
 
+        Args:
+            ext: HBP extension.
+            module: Convolution layer.
+
+        Raises:
+            NotImplementedError: If the backpropagation strategy differs from KFAC.
+
+        Returns:
+            List containing the tensor of the un-centered covariance of the unfolded
+            input. For a convolution with kernel of size `[_, C_in, K_H, K_W]`, its
+            shape is shape `[C_in * K_H * K_W, C_in * K_H * K_W]`.
+        """
         ea_strategy = ext.get_ea_strategy()
-
         if ExpectationApproximation.should_average_param_jac(ea_strategy):
             raise NotImplementedError("Undefined")
-        else:
-            yield einsum("bik,bjk->ij", (X, X)) / batch
 
-    def _factor_from_sqrt(self, module, backproped):
+        X = convUtils.unfold_input(module, module.input0)
+
+        return [einsum("bik,bjk->ij", X, X) / X.shape[0]]
+
+    def _factor_from_sqrt(self, module: Conv2d, backproped: Tensor) -> Tensor:
+        """Compute the Kronecker factor from the backpropagated GGN matrix square root.
+
+        In the notation of https://arxiv.org/pdf/1602.01407.pdf,
+        this computes |Τ| * Γ from equation (32) for KFAC.
+
+        Note:
+            In comparison to the KFC paper, the output differs by a factor of |Τ|.
+            This is because |Τ| * Γ is the MC/exact GGN w.r.t. the convolution's bias.
+            For two-dimensional convolution with output of shape `[N, C_out, H, W]`,
+            |Τ| = H * W.
+
+        Args:
+            module: Convolution layer.
+            backproped: Backpropagated quantity, corresponding to the MC/exact matrix
+                square square root of the GGN w.r.t. the convolution output. For a
+                convolution with output shape `[N, C_out, H, W]`, this square root is
+                of shape `[M, N, C_out, H, W]` where `M` is the number of MC samples
+                for KFAC, and the number of classes for KFLR. The matrix square root
+                already incorporates a normalization factor for batch size averaging.
+
+        Returns:
+            MC/exact GGN w.r.t. the bias. Has shape `[C_out, C_out]`
+        """
         num_spatial_dims = 2
 
         sqrt_ggn = backproped.flatten(start_dim=-num_spatial_dims)
         sqrt_ggn = einsum("cbij->cbi", sqrt_ggn)
         return einsum("cbi,cbl->il", sqrt_ggn, sqrt_ggn)
 
-    def bias(self, ext, module, g_inp, g_out, backproped):
+    def bias(
+        self,
+        ext: HBP,
+        module: Conv2d,
+        g_inp: Tuple[Tensor],
+        g_out: Tuple[Tensor],
+        backproped: Tensor,
+    ) -> List[Tensor]:
+        """Compute the Kronecker factors for the bias Hessian approximation.
+
+        Args:
+            ext: HBP extension.
+            module: convolution layer the backpropagation is performed on.
+            g_inp: input gradient.
+            g_out: output gradient.
+            backproped: Backpropagated quantity, depends on the approximation mode.
+                For KFLR/KFAC this is the MC/exact matrix square root of the GGN w.r.t.
+                the convolution output (shape `[M, N, C, H, W]`) and has shape
+                `[M, N, C, H, W]` with `M` the number of MC samples or the number of
+                classes for KFAC/KFLR, respectively. For KFRA, the backpropagated
+                object approximates the batch-averaged GGN w.r.t. to the convolution
+                output and has shape `[C * H * W, C * H * W]`.
+
+        Returns:
+            List of Kronecker factors whose Kronecker product approximates the bias
+            Hessian. Its length depends on the Hessian approximation. If `[A, B, C]`
+            is returned, then `A ⊗ B ⊗ C` has shape `[bias.numel(), bias.numel()]`
+            and approximates the bias Hessian.
+        """
+        kron_factors: List[Tensor] = []
         bp_strategy = ext.get_backprop_strategy()
 
-        if BackpropStrategy.is_batch_average(bp_strategy):
-            return self._bias_for_batch_average(module, backproped)
-        elif BackpropStrategy.is_sqrt(bp_strategy):
-            return self._bias_for_sqrt(module, backproped)
+        # TODO Find a setting in which this corresponds to an autodiff quantity, test
+        if BackpropStrategy.is_batch_average(bp_strategy):  # KFRA
+            kron_factors.append(self._factor_from_batch_average(module, backproped))
+        elif BackpropStrategy.is_sqrt(bp_strategy):  # KFAC/KFLR
+            kron_factors.append(self._factor_from_sqrt(module, backproped))
 
-    def _bias_for_sqrt(self, module, backproped):
-        return [self._factor_from_sqrt(module, backproped)]
+        return kron_factors
 
-    # TODO: Require tests
-    def _bias_for_batch_average(self, module, backproped):
-        return [self._factor_from_batch_average(module, backproped)]
+    def _factor_from_batch_average(self, module: Conv2d, backproped: Tensor) -> Tensor:
+        """Compute the Kronecker factor from the backpropagated output Hessian proxy.
 
-    def _factor_from_batch_average(self, module, backproped):
+        Note:
+            TODO Currently, the Kronecker approximation that needs to be imposed on
+            the backpropagated Hessian proxy to achieve a Kronecker structure of the
+            weight Hessian differs from KFC (https://arxiv.org/pdf/1602.01407.pdf).
+            This could be changed for this factor to be more consistent with the
+            KFC approximations. If this is changed, this must be clearly communicated
+            to users as it will alter the KFRA quantity for weights of
+            convolutions in comparison to older versions. NOTE that this method is
+            currently shared by the weights and bias terms for KFRA, but the described
+            improvement would only apply to the weights, and not the bias.
+
+        Args:
+            module: Convolution layer.
+            backproped: Approximation for the batch-averaged Hessian w.r.t. the output
+                of the convolution layer. Has shape `[C * H * W, C * H * W]` if the
+                convolution's output is of shape `[N, C, H, W]`.
+
+        Returns:
+            Kronecker factor used for approximating the weight Hessian in convolutions.
+            Has shape `[C, C]` with `C` the convolution's output channels.
+        """
         _, out_c, out_x, out_y = module.output.size()
         out_pixels = out_x * out_y
         # sum over spatial coordinates
         result = backproped.view(out_c, out_pixels, out_c, out_pixels).sum([1, 3])
         return result.contiguous()
+
+    @staticmethod
+    def _maybe_raise_groups_not_implemented_error(ext: HBP, module: Conv2d):
+        """Raise NotImplementedError for grouped convolution.
+
+        Args:
+            ext: HBP extension.
+            module: Convolution layer.
+
+        Raises:
+            NotImplementedError: If groups ≠ 1.
+        """
+        if module.groups != 1:
+            ext_name = ext.__class__.__name__
+            raise NotImplementedError(
+                f"groups ≠ 1 is not supported by {ext_name} (got {module.groups})."
+            )

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -68,6 +68,7 @@ backpack/extensions/secondorder/diag_hessian/pad.py
 backpack/extensions/secondorder/diag_hessian/slicing.py
 backpack/extensions/secondorder/sqrt_ggn/
 backpack/extensions/secondorder/hbp/custom_module.py
+backpack/extensions/secondorder/hbp/conv2d.py
 
 backpack/hessianfree/ggnvp.py
 

--- a/test/extensions/secondorder/hbp/kfac_settings.py
+++ b/test/extensions/secondorder/hbp/kfac_settings.py
@@ -9,7 +9,9 @@ from test.extensions.secondorder.secondorder_settings import (
 from torch import rand
 from torch.nn import (
     BCEWithLogitsLoss,
+    Conv2d,
     CrossEntropyLoss,
+    Flatten,
     Identity,
     Linear,
     MSELoss,
@@ -54,6 +56,16 @@ _BATCH_SIZE_1_NO_BRANCHING_SETTINGS = [
         "loss_function_fn": lambda: BCEWithLogitsLoss(reduction="sum"),
         "target_fn": lambda: classification_targets(size=(1, 1), num_classes=2).float(),
         "id_prefix": "binary-labels",
+    },
+    # convolution with single output is a linear layer (no weight sharing across input)
+    {
+        "input_fn": lambda: rand(1, 2, 3, 3),
+        "module_fn": lambda: Sequential(
+            Conv2d(2, 4, 3), ReLU(), Conv2d(4, 1, 1), Flatten()
+        ),
+        "loss_function_fn": lambda: MSELoss(reduction="mean"),
+        "target_fn": lambda: regression_targets((1, 1)),
+        "id_prefix": "convolution-single-output",
     },
 ]
 

--- a/test/extensions/secondorder/hbp/kfra_settings.py
+++ b/test/extensions/secondorder/hbp/kfra_settings.py
@@ -1,5 +1,8 @@
 """Define test cases for KFRA."""
 
+from test.extensions.secondorder.hbp.kfac_settings import (
+    _BATCH_SIZE_1_NO_BRANCHING_SETTINGS,
+)
 from test.extensions.secondorder.secondorder_settings import (
     GROUP_CONV_SETTINGS,
     LINEAR_ADDITIONAL_DIMENSIONS_SETTINGS,
@@ -11,3 +14,5 @@ SHARED_NOT_SUPPORTED_SETTINGS = (
 LOCAL_NOT_SUPPORTED_SETTINGS = []
 
 NOT_SUPPORTED_SETTINGS = SHARED_NOT_SUPPORTED_SETTINGS + LOCAL_NOT_SUPPORTED_SETTINGS
+
+BATCH_SIZE_1_SETTINGS = _BATCH_SIZE_1_NO_BRANCHING_SETTINGS

--- a/test/extensions/secondorder/hbp/test_kfra.py
+++ b/test/extensions/secondorder/hbp/test_kfra.py
@@ -1,21 +1,28 @@
 """Test BackPACK's KFRA extension."""
 
 from test.extensions.implementation.backpack import BackpackExtensions
-from test.extensions.problem import make_test_problems
-from test.extensions.secondorder.hbp.kfra_settings import NOT_SUPPORTED_SETTINGS
+from test.extensions.problem import ExtensionsTestProblem, make_test_problems
+from test.extensions.secondorder.hbp.kfra_settings import (
+    BATCH_SIZE_1_SETTINGS,
+    NOT_SUPPORTED_SETTINGS,
+)
+from test.utils.skip_extension_test import skip_BCEWithLogitsLoss
 
 import pytest
+from torch import Tensor, prod
 
 NOT_SUPPORTED_PROBLEMS = make_test_problems(NOT_SUPPORTED_SETTINGS)
 NOT_SUPPORTED_IDS = [problem.make_id() for problem in NOT_SUPPORTED_PROBLEMS]
+BATCH_SIZE_1_PROBLEMS = make_test_problems(BATCH_SIZE_1_SETTINGS)
+BATCH_SIZE_1_IDS = [problem.make_id() for problem in BATCH_SIZE_1_PROBLEMS]
 
 
 @pytest.mark.parametrize("problem", NOT_SUPPORTED_PROBLEMS, ids=NOT_SUPPORTED_IDS)
-def test_kfra_not_supported(problem):
+def test_kfra_not_supported(problem: ExtensionsTestProblem):
     """Check that the KFRA extension does not allow specific hyperparameters/modules.
 
     Args:
-        problem (ExtensionsTestProblem): Test case.
+        problem: Test case.
     """
     problem.set_up()
 
@@ -23,3 +30,26 @@ def test_kfra_not_supported(problem):
         BackpackExtensions(problem).kfra()
 
     problem.tear_down()
+
+
+@pytest.mark.parametrize("problem", BATCH_SIZE_1_PROBLEMS, ids=BATCH_SIZE_1_IDS)
+def test_kfra_dimensions(problem: ExtensionsTestProblem):
+    """Check that block Hessian approximation of KFRA has correct dimension.
+
+    This test runs KFRA code, but due to the approximations made in KFRA, a case
+    where it becomes exact and can therefore be tested for correct values still
+    needs to be identified.
+
+    Args:
+        problem: Test case.
+    """
+    problem.set_up()
+    skip_BCEWithLogitsLoss(problem)
+
+    backpack_kfra = BackpackExtensions(problem).kfra()
+    for p, p_kfra in zip(problem.trainable_parameters(), backpack_kfra):
+        assert all(kron.dim() == 2 for kron in p_kfra)
+        assert all(kron.shape[0] == kron.shape[1] for kron in p_kfra)
+
+        kron_dims = Tensor([kron_fac.shape[0] for kron_fac in p_kfra])
+        assert p.numel() == prod(kron_dims)

--- a/test/utils/skip_extension_test.py
+++ b/test/utils/skip_extension_test.py
@@ -16,3 +16,13 @@ def skip_BCEWithLogitsLoss_non_binary_labels(problem: ExtensionsTestProblem) -> 
         y not in [0, 1] for y in problem.target.flatten()
     ):
         skip("Skipping BCEWithLogitsLoss with non-binary labels")
+
+
+def skip_BCEWithLogitsLoss(problem: ExtensionsTestProblem) -> None:
+    """Skip if case uses BCEWithLogitsLoss as loss function.
+
+    Args:
+        problem: Extension test case.
+    """
+    if isinstance(problem.loss_function, BCEWithLogitsLoss):
+        skip("Skipping BCEWithLogitsLoss")


### PR DESCRIPTION
This PR adds documentation to the `HBP` extension of `Conv2d` layers, which is responsible to compute `KFAC/KFLR/KFRA`. The docstrings draw connections to the notation in the [KFC paper](https://arxiv.org/pdf/1602.01407.pdf), and outline important differences, as well as improvements for consistency. It also adds a test case for `KFAC, KFLR` for which both approximations become exact.

Note to myself: I made notes how to connect Hessian backpropagation to `KFAC` for convolutions by imposing a Kronecker structure on the backpropagated quantity. This concept can also be applied to `KFRA` to achieve more consistency, but is currently not done by the code.

