### PR TITLE
[FIX] Support for `torch>=1.13`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,13 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        pytorch-version: [1.12.1, 1.13]
+        pytorch-version:
+          - "==1.9"
+          - "==1.10"
+          - "==1.11"
+          - "==1.12"
+          - "==1.13"
+          - "" # latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
@@ -30,7 +36,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         make install-test
-        pip install torch==${{ matrix.pytorch-version }} torchvision
+        pip install torch${{ matrix.pytorch-version }} torchvision
     - name: Run test
       if: contains('refs/heads/master refs/heads/development refs/heads/release', github.ref)
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         pytorch-version:
-          - "==1.9"
-          - "==1.10"
-          - "==1.11"
-          - "==1.12"
-          - "==1.13"
+          - "==1.9.1"
+          - "==1.10.1"
+          - "==1.11.0"
+          - "==1.12.1"
+          - "==1.13.1"
           - "" # latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        pytorch-version: [1.9.0, 1.9.1]
+        pytorch-version: [1.12.1, 1.13]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/backpack/core/derivatives/basederivatives.py
+++ b/backpack/core/derivatives/basederivatives.py
@@ -9,7 +9,7 @@ from torch.nn import Module
 from backpack.core.derivatives import shape_check
 
 
-class BaseDerivatives(ABC):
+class BaseDerivatives(ABC):  # noqa: B024
     """First- and second-order partial derivatives of unparameterized module.
 
     Note:

--- a/backpack/core/derivatives/conv_transposend.py
+++ b/backpack/core/derivatives/conv_transposend.py
@@ -5,10 +5,9 @@ from einops import rearrange
 from numpy import prod
 from torch import Tensor, einsum
 from torch.nn import ConvTranspose1d, ConvTranspose2d, ConvTranspose3d, Module
-from torch.nn.grad import _grad_input_padding
 
 from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
-from backpack.utils.conv import get_conv_function
+from backpack.utils.conv import _grad_input_padding, get_conv_function
 from backpack.utils.conv_transpose import (
     get_conv_transpose_function,
     unfold_by_conv_transpose,

--- a/backpack/core/derivatives/conv_transposend.py
+++ b/backpack/core/derivatives/conv_transposend.py
@@ -7,12 +7,18 @@ from torch import Tensor, einsum
 from torch.nn import ConvTranspose1d, ConvTranspose2d, ConvTranspose3d, Module
 
 from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
-from backpack.utils.conv import _grad_input_padding, get_conv_function
+from backpack.utils import TORCH_VERSION_AT_LEAST_1_13
+from backpack.utils.conv import get_conv_function
 from backpack.utils.conv_transpose import (
     get_conv_transpose_function,
     unfold_by_conv_transpose,
 )
 from backpack.utils.subsampling import subsample
+
+if TORCH_VERSION_AT_LEAST_1_13:
+    from backpack.utils.conv import _grad_input_padding
+else:
+    from torch.nn.grad import _grad_input_padding
 
 
 class ConvTransposeNDDerivatives(BaseParameterDerivatives):

--- a/backpack/core/derivatives/convnd.py
+++ b/backpack/core/derivatives/convnd.py
@@ -7,9 +7,15 @@ from torch import Tensor, einsum
 from torch.nn import Conv1d, Conv2d, Conv3d, Module
 
 from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
-from backpack.utils.conv import _grad_input_padding, get_conv_function, unfold_by_conv
+from backpack.utils import TORCH_VERSION_AT_LEAST_1_13
+from backpack.utils.conv import get_conv_function, unfold_by_conv
 from backpack.utils.conv_transpose import get_conv_transpose_function
 from backpack.utils.subsampling import subsample
+
+if TORCH_VERSION_AT_LEAST_1_13:
+    from backpack.utils.conv import _grad_input_padding
+else:
+    from torch.nn.grad import _grad_input_padding
 
 
 class weight_jac_t_save_memory:

--- a/backpack/core/derivatives/convnd.py
+++ b/backpack/core/derivatives/convnd.py
@@ -5,10 +5,9 @@ from einops import rearrange, reduce
 from numpy import prod
 from torch import Tensor, einsum
 from torch.nn import Conv1d, Conv2d, Conv3d, Module
-from torch.nn.grad import _grad_input_padding
 
 from backpack.core.derivatives.basederivatives import BaseParameterDerivatives
-from backpack.utils.conv import get_conv_function, unfold_by_conv
+from backpack.utils.conv import _grad_input_padding, get_conv_function, unfold_by_conv
 from backpack.utils.conv_transpose import get_conv_transpose_function
 from backpack.utils.subsampling import subsample
 

--- a/backpack/utils/__init__.py
+++ b/backpack/utils/__init__.py
@@ -4,5 +4,6 @@ from pkg_resources import get_distribution, packaging
 TORCH_VERSION = packaging.version.parse(get_distribution("torch").version)
 TORCH_VERSION_AT_LEAST_1_9_1 = TORCH_VERSION >= packaging.version.parse("1.9.1")
 TORCH_VERSION_AT_LEAST_2_0_0 = TORCH_VERSION >= packaging.version.parse("2.0.0")
+TORCH_VERSION_AT_LEAST_1_13 = TORCH_VERSION >= packaging.version.parse("1.13")
 
 ADAPTIVE_AVG_POOL_BUG: bool = not TORCH_VERSION_AT_LEAST_2_0_0

--- a/backpack/utils/conv.py
+++ b/backpack/utils/conv.py
@@ -1,4 +1,5 @@
 from typing import Callable, Type, Union
+from warnings import warn
 
 import torch
 from einops import rearrange
@@ -164,3 +165,48 @@ def unfold_by_conv(input, module):
     )
 
     return unfold.reshape(N, C_in * kernel_size_numel, -1)
+
+
+def _grad_input_padding(
+    grad_output, input_size, stride, padding, kernel_size, dilation=None
+):
+    """Determine padding for the VJP of convolution.
+
+    Note:
+        This function was copied from the PyTorch repository (version 1.9).
+        It was removed between torch 1.12.1 and torch 1.13.
+    """
+    if dilation is None:
+        # For backward compatibility
+        warn(
+            "_grad_input_padding 'dilation' argument not provided. Default of 1 is used."
+        )
+        dilation = [1] * len(stride)
+
+    input_size = list(input_size)
+    k = grad_output.dim() - 2
+
+    if len(input_size) == k + 2:
+        input_size = input_size[-k:]
+    if len(input_size) != k:
+        raise ValueError(f"input_size must have {k+2} elements (got {len(input_size)})")
+
+    def dim_size(d):
+        return (
+            (grad_output.size(d + 2) - 1) * stride[d]
+            - 2 * padding[d]
+            + 1
+            + dilation[d] * (kernel_size[d] - 1)
+        )
+
+    min_sizes = [dim_size(d) for d in range(k)]
+    max_sizes = [min_sizes[d] + stride[d] - 1 for d in range(k)]
+    for size, min_size, max_size in zip(input_size, min_sizes, max_sizes):
+        if size < min_size or size > max_size:
+            raise ValueError(
+                f"requested an input grad size of {input_size}, but valid sizes range "
+                f"from {min_sizes} to {max_sizes} (for a grad_output of "
+                f"{grad_output.size()[2:]})"
+            )
+
+    return tuple(input_size[d] - min_sizes[d] for d in range(k))

--- a/backpack/utils/examples.py
+++ b/backpack/utils/examples.py
@@ -113,5 +113,6 @@ def _autograd_ggn_exact_columns(
         e_d_list = vector_to_parameter_list(e_d, trainable_parameters)
 
         ggn_d_list = ggn_vector_product(loss, outputs, model, e_d_list)
+        ggn_d_list = [t.contiguous() for t in ggn_d_list]
 
         yield d, parameters_to_vector(ggn_d_list)

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,6 +106,7 @@ ignore =
 	W291, # trailing whitespace
 	W503, # line break before binary operator
 	W504, # line break after binary operator
+  B905, # 'zip()' without an explicit 'strict=' parameter
 exclude = docs, build, .git, docs_src/rtd, docs_src/rtd_output, .eggs
 
 # Differences with pytorch

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -248,7 +248,7 @@ class AutogradDerivatives(DerivativesImplementation):
         for t in tensor.flatten():
             try:
                 yield self._hessian(t, x)
-            except (RuntimeError, AttributeError):
+            except (RuntimeError, AttributeError, TypeError):
                 yield zeros(*x.shape, *x.shape, device=x.device, dtype=x.dtype)
 
     def hessian_is_zero(self) -> bool:  # noqa: D102


### PR DESCRIPTION
Fixes #272.

- Adapt test CI to run tests with multiple torch versions, including 1.13
- Add `_grad_input_padding` function that was removed in 1.13 as utility and import if the installed torch version doesn't include it anymore
- `parameters_to_vector` stopped working for tensor lists with non-contiguous entries. Fix by calling `contiguous()` before vectorizing.
- torch raises a new exception (`TypeError`) when trying to compute the Hessian of a linear function. Fix by adding the new exception to the catched exceptions.