### PR TITLE
[CI] Drop `system_packages` in RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,10 +7,9 @@ sphinx:
   configuration: docs_src/rtd/conf.py
 
 python:
-  version: 3.8
+  version: "3.8"
   install:
     - method: pip
       path: .
       extra_requirements:
         - docs
-  system_packages: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ lint =
 # Dependencies needed to build/view the documentation (semicolon/line-separated)
 docs =
     matplotlib
+    sphinx<7
     sphinx-gallery
     sphinx-rtd-theme
     memory_profiler


### PR DESCRIPTION
`system_packages` were deprecated on August 29, see https://blog.readthedocs.com/drop-support-system-packages/.