### PR TITLE
[FIX | FMT] RTD build, apply latest `black` and `isort`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,10 +46,3 @@ jobs:
       if: contains('refs/heads/master refs/heads/development refs/heads/release', github.ref) != 1
       run: |
         make test-light
-
-    - name: Test coveralls - python ${{ matrix.python-version }}
-      run: coveralls --service=github
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: run-${{ matrix.python-version }}
-        parallel: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,10 +6,14 @@ version: 2
 sphinx:
   configuration: docs_src/rtd/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 python:
-  version: "3.8"
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  - method: pip
+    path: .
+    extra_requirements:
+      - docs

--- a/backpack/__init__.py
+++ b/backpack/__init__.py
@@ -1,4 +1,5 @@
 """BackPACK."""
+
 from inspect import isclass
 from types import TracebackType
 from typing import Callable, Optional, Tuple, Type, Union

--- a/backpack/context.py
+++ b/backpack/context.py
@@ -1,4 +1,5 @@
 """Context class for BackPACK."""
+
 from typing import Callable, Iterable, List, Tuple, Type
 
 from torch.nn import Module

--- a/backpack/core/derivatives/adaptive_avg_pool_nd.py
+++ b/backpack/core/derivatives/adaptive_avg_pool_nd.py
@@ -1,4 +1,5 @@
 """Implements the derivatives for AdaptiveAvgPool."""
+
 from typing import List, Tuple, Union
 from warnings import warn
 

--- a/backpack/core/derivatives/avgpoolnd.py
+++ b/backpack/core/derivatives/avgpoolnd.py
@@ -3,6 +3,7 @@
 Average pooling can be expressed as convolution over grouped channels with a constant
 kernel.
 """
+
 from typing import Any, List, Tuple
 
 from einops import rearrange

--- a/backpack/core/derivatives/basederivatives.py
+++ b/backpack/core/derivatives/basederivatives.py
@@ -1,4 +1,5 @@
 """Base classes for more flexible Jacobians and second-order information."""
+
 import warnings
 from abc import ABC
 from typing import Callable, List, Tuple

--- a/backpack/core/derivatives/batchnorm_nd.py
+++ b/backpack/core/derivatives/batchnorm_nd.py
@@ -1,4 +1,5 @@
 """Contains derivatives for BatchNorm."""
+
 from typing import List, Tuple, Union
 
 from torch import Size, Tensor, einsum

--- a/backpack/core/derivatives/conv_transposend.py
+++ b/backpack/core/derivatives/conv_transposend.py
@@ -1,4 +1,5 @@
 """Partial derivatives for ``torch.nn.ConvTranspose{1,2,3}d``."""
+
 from typing import List, Tuple, Union
 
 from einops import rearrange

--- a/backpack/core/derivatives/crossentropyloss.py
+++ b/backpack/core/derivatives/crossentropyloss.py
@@ -1,4 +1,5 @@
 """Partial derivatives for cross-entropy loss."""
+
 from math import sqrt
 from typing import Callable, Dict, List, Tuple
 

--- a/backpack/core/derivatives/dropout.py
+++ b/backpack/core/derivatives/dropout.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the dropout layer."""
+
 from typing import List, Tuple
 
 from torch import Tensor, eq, ones_like

--- a/backpack/core/derivatives/elu.py
+++ b/backpack/core/derivatives/elu.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the ELU activation function."""
+
 from typing import List, Tuple
 
 from torch import Tensor, exp, le, ones_like, zeros_like

--- a/backpack/core/derivatives/embedding.py
+++ b/backpack/core/derivatives/embedding.py
@@ -1,4 +1,5 @@
 """Derivatives for Embedding."""
+
 from typing import List, Tuple
 
 from torch import Tensor, einsum, zeros

--- a/backpack/core/derivatives/flatten.py
+++ b/backpack/core/derivatives/flatten.py
@@ -1,4 +1,5 @@
 """Partial derivatives of the flatten layer."""
+
 from typing import List, Tuple
 
 from torch import Tensor

--- a/backpack/core/derivatives/leakyrelu.py
+++ b/backpack/core/derivatives/leakyrelu.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the leaky ReLU layer."""
+
 from typing import List, Tuple
 
 from torch import Tensor, gt

--- a/backpack/core/derivatives/linear.py
+++ b/backpack/core/derivatives/linear.py
@@ -1,4 +1,5 @@
 """Contains partial derivatives for the ``torch.nn.Linear`` layer."""
+
 from typing import List, Tuple
 
 from torch import Size, Tensor, einsum

--- a/backpack/core/derivatives/logsigmoid.py
+++ b/backpack/core/derivatives/logsigmoid.py
@@ -1,4 +1,5 @@
 """Contains partial derivatives for the ``torch.nn.LogSigmoid`` layer."""
+
 from typing import List, Tuple
 
 from torch import Tensor, exp

--- a/backpack/core/derivatives/lstm.py
+++ b/backpack/core/derivatives/lstm.py
@@ -1,4 +1,5 @@
 """Partial derivatives for nn.LSTM."""
+
 from typing import List, Tuple
 
 from torch import Tensor, cat, einsum, sigmoid, tanh, zeros

--- a/backpack/core/derivatives/nll_base.py
+++ b/backpack/core/derivatives/nll_base.py
@@ -1,4 +1,5 @@
 """Partial derivative bases for NLL losses."""
+
 from math import sqrt
 from typing import List, Tuple
 

--- a/backpack/core/derivatives/permute.py
+++ b/backpack/core/derivatives/permute.py
@@ -1,4 +1,5 @@
 """Module containing derivatives of Permute."""
+
 from typing import List, Tuple
 
 from torch import Tensor, argsort

--- a/backpack/core/derivatives/relu.py
+++ b/backpack/core/derivatives/relu.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the ReLU activation function."""
+
 from typing import List, Tuple
 
 from torch import Tensor, gt

--- a/backpack/core/derivatives/rnn.py
+++ b/backpack/core/derivatives/rnn.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the torch.nn.RNN layer."""
+
 from typing import List, Tuple
 
 from torch import Tensor, cat, einsum, zeros

--- a/backpack/core/derivatives/scale_module.py
+++ b/backpack/core/derivatives/scale_module.py
@@ -1,4 +1,5 @@
 """Derivatives of ScaleModule (implies Identity)."""
+
 from typing import List, Tuple, Union
 
 from torch import Tensor

--- a/backpack/core/derivatives/selu.py
+++ b/backpack/core/derivatives/selu.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the SELU activation function."""
+
 from typing import List, Tuple
 
 from torch import Tensor, exp, le, ones_like, zeros_like

--- a/backpack/core/derivatives/shape_check.py
+++ b/backpack/core/derivatives/shape_check.py
@@ -2,6 +2,7 @@
 
 Helpers to check input and output sizes of Jacobian-matrix products.
 """
+
 import functools
 from typing import Any, Callable
 

--- a/backpack/core/derivatives/sigmoid.py
+++ b/backpack/core/derivatives/sigmoid.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the Sigmoid activation function."""
+
 from typing import List, Tuple
 
 from torch import Tensor

--- a/backpack/core/derivatives/slicing.py
+++ b/backpack/core/derivatives/slicing.py
@@ -1,4 +1,5 @@
 """Contains derivatives of slicing operation."""
+
 from typing import List, Tuple
 
 from torch import Tensor, zeros

--- a/backpack/core/derivatives/sum_module.py
+++ b/backpack/core/derivatives/sum_module.py
@@ -1,4 +1,5 @@
 """Contains derivatives for SumModule."""
+
 from typing import List, Tuple
 
 from torch import Tensor

--- a/backpack/core/derivatives/tanh.py
+++ b/backpack/core/derivatives/tanh.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the Tanh activation function."""
+
 from typing import List, Tuple
 
 from torch import Tensor

--- a/backpack/core/derivatives/zeropad2d.py
+++ b/backpack/core/derivatives/zeropad2d.py
@@ -1,4 +1,5 @@
 """Partial derivatives for the ZeroPad2d function."""
+
 from typing import List, Tuple
 
 from einops import rearrange

--- a/backpack/custom_module/branching.py
+++ b/backpack/custom_module/branching.py
@@ -1,4 +1,5 @@
 """Emulating branching with modules."""
+
 from typing import Any, OrderedDict, Tuple, Union
 
 from torch import Tensor

--- a/backpack/custom_module/graph_utils.py
+++ b/backpack/custom_module/graph_utils.py
@@ -1,4 +1,5 @@
 """Transformation tools to make graph BackPACK compatible."""
+
 from copy import deepcopy
 from typing import Tuple, Union
 from warnings import warn

--- a/backpack/custom_module/permute.py
+++ b/backpack/custom_module/permute.py
@@ -1,4 +1,5 @@
 """Module containing Permute module."""
+
 from typing import Any
 
 from torch import Tensor

--- a/backpack/custom_module/reduce_tuple.py
+++ b/backpack/custom_module/reduce_tuple.py
@@ -1,4 +1,5 @@
 """Module containing ReduceTuple module."""
+
 from typing import Union
 
 from torch import Tensor

--- a/backpack/custom_module/scale_module.py
+++ b/backpack/custom_module/scale_module.py
@@ -1,4 +1,5 @@
 """Contains ScaleModule."""
+
 from torch import Tensor
 from torch.nn import Module
 

--- a/backpack/extensions/backprop_extension.py
+++ b/backpack/extensions/backprop_extension.py
@@ -1,4 +1,5 @@
 """Implements the backpropagation mechanism."""
+
 from __future__ import annotations
 
 import abc

--- a/backpack/extensions/curvmatprod/__init__.py
+++ b/backpack/extensions/curvmatprod/__init__.py
@@ -20,7 +20,6 @@ backpropagation, described in:
   by Felix Dangel, Stefan Harmeling, Philipp Hennig, 2020.
 """
 
-
 from .ggnmp import GGNMP
 from .hmp import HMP
 from .pchmp import PCHMP

--- a/backpack/extensions/firstorder/base.py
+++ b/backpack/extensions/firstorder/base.py
@@ -1,4 +1,5 @@
 """Base class for first order extensions."""
+
 from typing import Dict, List, Type
 
 from torch.nn import Module

--- a/backpack/extensions/firstorder/batch_grad/__init__.py
+++ b/backpack/extensions/firstorder/batch_grad/__init__.py
@@ -2,6 +2,7 @@
 
 It defines the module extension for each module.
 """
+
 from typing import List
 
 from torch.nn import (

--- a/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
+++ b/backpack/extensions/firstorder/batch_grad/batch_grad_base.py
@@ -1,4 +1,5 @@
 """Calculates the batch_grad derivative."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, List, Tuple

--- a/backpack/extensions/firstorder/batch_grad/batchnorm_nd.py
+++ b/backpack/extensions/firstorder/batch_grad/batchnorm_nd.py
@@ -1,4 +1,5 @@
 """Contains grad_batch extension for BatchNorm."""
+
 from typing import Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/firstorder/batch_grad/embedding.py
+++ b/backpack/extensions/firstorder/batch_grad/embedding.py
@@ -1,4 +1,5 @@
 """BatchGrad extension for Embedding."""
+
 from backpack.core.derivatives.embedding import EmbeddingDerivatives
 from backpack.extensions.firstorder.batch_grad.batch_grad_base import BatchGradBase
 

--- a/backpack/extensions/firstorder/batch_grad/rnn.py
+++ b/backpack/extensions/firstorder/batch_grad/rnn.py
@@ -1,4 +1,5 @@
 """Contains BatchGradRNN."""
+
 from backpack.core.derivatives.lstm import LSTMDerivatives
 from backpack.core.derivatives.rnn import RNNDerivatives
 from backpack.extensions.firstorder.batch_grad.batch_grad_base import BatchGradBase

--- a/backpack/extensions/firstorder/batch_l2_grad/__init__.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/__init__.py
@@ -3,6 +3,7 @@
 Defines the backpropagation extension.
 Within it, define the extension for each module.
 """
+
 from torch.nn import (
     LSTM,
     RNN,

--- a/backpack/extensions/firstorder/batch_l2_grad/batch_l2_base.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/batch_l2_base.py
@@ -1,4 +1,5 @@
 """Contains Base class for batch_l2_grad."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, List, Tuple

--- a/backpack/extensions/firstorder/batch_l2_grad/batchnorm_nd.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/batchnorm_nd.py
@@ -1,4 +1,5 @@
 """Contains batch_l2 extension for BatchNorm."""
+
 from typing import Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/firstorder/batch_l2_grad/convnd.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/convnd.py
@@ -1,4 +1,5 @@
 """batch_l2 extension for Conv."""
+
 from torch import einsum
 
 from backpack.core.derivatives.conv1d import Conv1DDerivatives

--- a/backpack/extensions/firstorder/batch_l2_grad/convtransposend.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/convtransposend.py
@@ -1,4 +1,5 @@
 """batch_l2 extension for ConvTranspose."""
+
 from torch import einsum
 
 from backpack.core.derivatives.conv_transpose1d import ConvTranspose1DDerivatives

--- a/backpack/extensions/firstorder/batch_l2_grad/embedding.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/embedding.py
@@ -1,4 +1,5 @@
 """BatchL2 extension for Embedding."""
+
 from backpack.core.derivatives.embedding import EmbeddingDerivatives
 from backpack.extensions.firstorder.batch_l2_grad.batch_l2_base import BatchL2Base
 

--- a/backpack/extensions/firstorder/batch_l2_grad/linear.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/linear.py
@@ -1,4 +1,5 @@
 """Contains batch_l2 extension for Linear."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple

--- a/backpack/extensions/firstorder/batch_l2_grad/rnn.py
+++ b/backpack/extensions/firstorder/batch_l2_grad/rnn.py
@@ -1,4 +1,5 @@
 """Contains BatchL2RNN."""
+
 from backpack.core.derivatives.lstm import LSTMDerivatives
 from backpack.core.derivatives.rnn import RNNDerivatives
 from backpack.extensions.firstorder.batch_l2_grad.batch_l2_base import BatchL2Base

--- a/backpack/extensions/firstorder/gradient/__init__.py
+++ b/backpack/extensions/firstorder/gradient/__init__.py
@@ -2,4 +2,5 @@
 
 It calculates the same result as torch backward().
 """
+
 # TODO: Rewrite variance to not need this extension

--- a/backpack/extensions/firstorder/gradient/base.py
+++ b/backpack/extensions/firstorder/gradient/base.py
@@ -1,4 +1,5 @@
 """Calculates the gradient."""
+
 from backpack.extensions.firstorder.base import FirstOrderModuleExtension
 
 

--- a/backpack/extensions/firstorder/gradient/batchnorm_nd.py
+++ b/backpack/extensions/firstorder/gradient/batchnorm_nd.py
@@ -1,4 +1,5 @@
 """Gradient extension for BatchNorm."""
+
 from typing import Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/firstorder/gradient/embedding.py
+++ b/backpack/extensions/firstorder/gradient/embedding.py
@@ -1,4 +1,5 @@
 """Gradient extension for Embedding."""
+
 from backpack.core.derivatives.embedding import EmbeddingDerivatives
 from backpack.extensions.firstorder.gradient.base import GradBaseModule
 

--- a/backpack/extensions/firstorder/gradient/rnn.py
+++ b/backpack/extensions/firstorder/gradient/rnn.py
@@ -1,4 +1,5 @@
 """Contains GradRNN."""
+
 from backpack.core.derivatives.lstm import LSTMDerivatives
 from backpack.core.derivatives.rnn import RNNDerivatives
 from backpack.extensions.firstorder.gradient.base import GradBaseModule

--- a/backpack/extensions/firstorder/sum_grad_squared/__init__.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/__init__.py
@@ -2,6 +2,7 @@
 
 Defines module extension for each module.
 """
+
 from torch.nn import (
     LSTM,
     RNN,

--- a/backpack/extensions/firstorder/sum_grad_squared/batchnorm_nd.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/batchnorm_nd.py
@@ -1,4 +1,5 @@
 """SGS extension for BatchNorm."""
+
 from typing import Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/firstorder/sum_grad_squared/embedding.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/embedding.py
@@ -1,4 +1,5 @@
 """SGS extension for Embedding."""
+
 from backpack.core.derivatives.embedding import EmbeddingDerivatives
 from backpack.extensions.firstorder.sum_grad_squared.sgs_base import SGSBase
 

--- a/backpack/extensions/firstorder/sum_grad_squared/rnn.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/rnn.py
@@ -1,4 +1,5 @@
 """Contains SGSRNN module."""
+
 from backpack.core.derivatives.lstm import LSTMDerivatives
 from backpack.core.derivatives.rnn import RNNDerivatives
 from backpack.extensions.firstorder.sum_grad_squared.sgs_base import SGSBase

--- a/backpack/extensions/firstorder/sum_grad_squared/sgs_base.py
+++ b/backpack/extensions/firstorder/sum_grad_squared/sgs_base.py
@@ -1,4 +1,5 @@
 """Contains SGSBase, the base module for sum_grad_squared extension."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, List, Tuple

--- a/backpack/extensions/firstorder/variance/__init__.py
+++ b/backpack/extensions/firstorder/variance/__init__.py
@@ -2,6 +2,7 @@
 
 Defines module extension for each module.
 """
+
 from torch.nn import (
     LSTM,
     RNN,

--- a/backpack/extensions/firstorder/variance/batchnorm_nd.py
+++ b/backpack/extensions/firstorder/variance/batchnorm_nd.py
@@ -1,4 +1,5 @@
 """Variance extension for BatchNorm."""
+
 from typing import Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/firstorder/variance/embedding.py
+++ b/backpack/extensions/firstorder/variance/embedding.py
@@ -1,4 +1,5 @@
 """Variance extension for Embedding."""
+
 from backpack.extensions.firstorder.gradient.embedding import GradEmbedding
 from backpack.extensions.firstorder.sum_grad_squared.embedding import SGSEmbedding
 from backpack.extensions.firstorder.variance.variance_base import VarianceBaseModule

--- a/backpack/extensions/firstorder/variance/variance_base.py
+++ b/backpack/extensions/firstorder/variance/variance_base.py
@@ -1,4 +1,5 @@
 """Contains VarianceBaseModule."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, List, Tuple

--- a/backpack/extensions/mat_to_mat_jac_base.py
+++ b/backpack/extensions/mat_to_mat_jac_base.py
@@ -1,4 +1,5 @@
 """Contains base class for second order extensions."""
+
 from typing import List, Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/module_extension.py
+++ b/backpack/extensions/module_extension.py
@@ -1,4 +1,5 @@
 """Contains base class for BackPACK module extensions."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Tuple

--- a/backpack/extensions/saved_quantities.py
+++ b/backpack/extensions/saved_quantities.py
@@ -1,4 +1,5 @@
 """Class for saving backpropagation quantities."""
+
 from typing import Any, Callable, Dict, Union
 
 from torch import Tensor

--- a/backpack/extensions/secondorder/base.py
+++ b/backpack/extensions/secondorder/base.py
@@ -1,4 +1,5 @@
 """Contains base classes for second order extensions."""
+
 from backpack.extensions.backprop_extension import BackpropExtension
 
 

--- a/backpack/extensions/secondorder/diag_ggn/__init__.py
+++ b/backpack/extensions/secondorder/diag_ggn/__init__.py
@@ -8,6 +8,7 @@ BatchDiagGGN(BackpropExtension)
 BatchDiagGGNExact(BatchDiagGGN)
 BatchDiagGGNMC(BatchDiagGGN)
 """
+
 from torch import Tensor
 from torch.nn import (
     ELU,

--- a/backpack/extensions/secondorder/diag_ggn/adaptive_avg_pool_nd.py
+++ b/backpack/extensions/secondorder/diag_ggn/adaptive_avg_pool_nd.py
@@ -1,4 +1,5 @@
 """DiagGGN extension for AdaptiveAvgPool."""
+
 from backpack.core.derivatives.adaptive_avg_pool_nd import AdaptiveAvgPoolNDDerivatives
 from backpack.extensions.secondorder.diag_ggn.diag_ggn_base import DiagGGNBaseModule
 

--- a/backpack/extensions/secondorder/diag_ggn/batchnorm_nd.py
+++ b/backpack/extensions/secondorder/diag_ggn/batchnorm_nd.py
@@ -1,4 +1,5 @@
 """DiagGGN extension for BatchNorm."""
+
 from typing import Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/secondorder/diag_ggn/custom_module.py
+++ b/backpack/extensions/secondorder/diag_ggn/custom_module.py
@@ -1,4 +1,5 @@
 """DiagGGN extensions for backpack's custom modules."""
+
 from backpack.core.derivatives.scale_module import ScaleModuleDerivatives
 from backpack.core.derivatives.sum_module import SumModuleDerivatives
 from backpack.extensions.secondorder.diag_ggn.diag_ggn_base import DiagGGNBaseModule

--- a/backpack/extensions/secondorder/diag_ggn/diag_ggn_base.py
+++ b/backpack/extensions/secondorder/diag_ggn/diag_ggn_base.py
@@ -1,4 +1,5 @@
 """Contains DiagGGN base class."""
+
 from typing import Callable, List, Tuple, Union
 
 from torch import Tensor

--- a/backpack/extensions/secondorder/diag_ggn/embedding.py
+++ b/backpack/extensions/secondorder/diag_ggn/embedding.py
@@ -1,4 +1,5 @@
 """DiagGGN extension for Embedding."""
+
 from backpack.core.derivatives.embedding import EmbeddingDerivatives
 from backpack.extensions.secondorder.diag_ggn.diag_ggn_base import DiagGGNBaseModule
 

--- a/backpack/extensions/secondorder/diag_ggn/permute.py
+++ b/backpack/extensions/secondorder/diag_ggn/permute.py
@@ -1,4 +1,5 @@
 """Module defining DiagGGNPermute."""
+
 from backpack.core.derivatives.permute import PermuteDerivatives
 from backpack.extensions.secondorder.diag_ggn.diag_ggn_base import DiagGGNBaseModule
 

--- a/backpack/extensions/secondorder/diag_ggn/rnn.py
+++ b/backpack/extensions/secondorder/diag_ggn/rnn.py
@@ -1,4 +1,5 @@
 """Module implementing GGN for RNN."""
+
 from backpack.core.derivatives.lstm import LSTMDerivatives
 from backpack.core.derivatives.rnn import RNNDerivatives
 from backpack.extensions.secondorder.diag_ggn.diag_ggn_base import DiagGGNBaseModule

--- a/backpack/extensions/secondorder/diag_hessian/__init__.py
+++ b/backpack/extensions/secondorder/diag_hessian/__init__.py
@@ -3,6 +3,7 @@
 - Hessian diagonal
 - Per-sample (individual) Hessian diagonal
 """
+
 from torch.nn import (
     ELU,
     SELU,

--- a/backpack/extensions/secondorder/diag_hessian/adaptive_avg_pool_nd.py
+++ b/backpack/extensions/secondorder/diag_hessian/adaptive_avg_pool_nd.py
@@ -1,4 +1,5 @@
 """DiagH extension for AdaptiveAvgPool."""
+
 from backpack.core.derivatives.adaptive_avg_pool_nd import AdaptiveAvgPoolNDDerivatives
 from backpack.extensions.secondorder.diag_hessian.diag_h_base import DiagHBaseModule
 

--- a/backpack/extensions/secondorder/diag_hessian/conv1d.py
+++ b/backpack/extensions/secondorder/diag_hessian/conv1d.py
@@ -1,4 +1,5 @@
 """Module extensions for diagonal Hessian properties of ``torch.nn.Conv1d``."""
+
 from backpack.core.derivatives.conv1d import Conv1DDerivatives
 from backpack.extensions.secondorder.diag_hessian.convnd import (
     BatchDiagHConvND,

--- a/backpack/extensions/secondorder/diag_hessian/conv2d.py
+++ b/backpack/extensions/secondorder/diag_hessian/conv2d.py
@@ -1,4 +1,5 @@
 """Module extensions for diagonal Hessian properties of ``torch.nn.Conv2d``."""
+
 from backpack.core.derivatives.conv2d import Conv2DDerivatives
 from backpack.extensions.secondorder.diag_hessian.convnd import (
     BatchDiagHConvND,

--- a/backpack/extensions/secondorder/diag_hessian/conv3d.py
+++ b/backpack/extensions/secondorder/diag_hessian/conv3d.py
@@ -1,4 +1,5 @@
 """Module extensions for diagonal Hessian properties of ``torch.nn.Conv3d``."""
+
 from backpack.core.derivatives.conv3d import Conv3DDerivatives
 from backpack.extensions.secondorder.diag_hessian.convnd import (
     BatchDiagHConvND,

--- a/backpack/extensions/secondorder/hbp/custom_module.py
+++ b/backpack/extensions/secondorder/hbp/custom_module.py
@@ -1,4 +1,5 @@
 """Module extensions for custom properties of HBPBaseModule."""
+
 from backpack.core.derivatives.scale_module import ScaleModuleDerivatives
 from backpack.core.derivatives.sum_module import SumModuleDerivatives
 from backpack.extensions.secondorder.hbp.hbpbase import HBPBaseModule

--- a/backpack/extensions/secondorder/sqrt_ggn/activations.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/activations.py
@@ -1,4 +1,5 @@
 """Contains extensions for activation layers used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.elu import ELUDerivatives
 from backpack.core.derivatives.leakyrelu import LeakyReLUDerivatives
 from backpack.core.derivatives.logsigmoid import LogSigmoidDerivatives

--- a/backpack/extensions/secondorder/sqrt_ggn/base.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/base.py
@@ -1,4 +1,5 @@
 """Contains base class for ``SqrtGGN{Exact, MC}`` module extensions."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, List, Tuple, Union
@@ -33,9 +34,7 @@ class SqrtGGNBaseModule(MatToJacMat):
 
         super().__init__(derivatives, params=params)
 
-    def _make_param_function(
-        self, param_str: str
-    ) -> Callable[
+    def _make_param_function(self, param_str: str) -> Callable[
         [Union[SqrtGGNExact, SqrtGGNMC], Module, Tuple[Tensor], Tuple[Tensor], Tensor],
         Tensor,
     ]:

--- a/backpack/extensions/secondorder/sqrt_ggn/convnd.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/convnd.py
@@ -1,4 +1,5 @@
 """Contains extensions for convolution layers used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.conv1d import Conv1DDerivatives
 from backpack.core.derivatives.conv2d import Conv2DDerivatives
 from backpack.core.derivatives.conv3d import Conv3DDerivatives

--- a/backpack/extensions/secondorder/sqrt_ggn/convtransposend.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/convtransposend.py
@@ -1,4 +1,5 @@
 """Contains transpose convolution layer extensions used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.conv_transpose1d import ConvTranspose1DDerivatives
 from backpack.core.derivatives.conv_transpose2d import ConvTranspose2DDerivatives
 from backpack.core.derivatives.conv_transpose3d import ConvTranspose3DDerivatives

--- a/backpack/extensions/secondorder/sqrt_ggn/dropout.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/dropout.py
@@ -1,4 +1,5 @@
 """Contains extensions for dropout layers used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.dropout import DropoutDerivatives
 from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
 

--- a/backpack/extensions/secondorder/sqrt_ggn/embedding.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/embedding.py
@@ -1,4 +1,5 @@
 """Contains extension for the embedding layer used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.embedding import EmbeddingDerivatives
 from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
 

--- a/backpack/extensions/secondorder/sqrt_ggn/flatten.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/flatten.py
@@ -1,4 +1,5 @@
 """Contains extensions for the flatten layer used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.flatten import FlattenDerivatives
 from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
 

--- a/backpack/extensions/secondorder/sqrt_ggn/linear.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/linear.py
@@ -1,4 +1,5 @@
 """Contains extension for the linear layer used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.linear import LinearDerivatives
 from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
 

--- a/backpack/extensions/secondorder/sqrt_ggn/losses.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/losses.py
@@ -1,4 +1,5 @@
 """Contains base class and extensions for losses used by ``SqrtGGN{Exact, MC}``."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple, Union

--- a/backpack/extensions/secondorder/sqrt_ggn/padding.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/padding.py
@@ -1,4 +1,5 @@
 """Contains extensions for padding layers used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.zeropad2d import ZeroPad2dDerivatives
 from backpack.extensions.secondorder.sqrt_ggn.base import SqrtGGNBaseModule
 

--- a/backpack/extensions/secondorder/sqrt_ggn/pooling.py
+++ b/backpack/extensions/secondorder/sqrt_ggn/pooling.py
@@ -1,4 +1,5 @@
 """Contains extensions for pooling layers used by ``SqrtGGN{Exact, MC}``."""
+
 from backpack.core.derivatives.avgpool1d import AvgPool1DDerivatives
 from backpack.core.derivatives.avgpool2d import AvgPool2DDerivatives
 from backpack.core.derivatives.avgpool3d import AvgPool3DDerivatives

--- a/backpack/hessianfree/ggnvp.py
+++ b/backpack/hessianfree/ggnvp.py
@@ -1,4 +1,5 @@
 """Autodiff-only matrix-free multiplication by the generalized Gauss-Newton/Fisher."""
+
 from typing import List, Tuple
 
 from torch import Tensor

--- a/backpack/utils/__init__.py
+++ b/backpack/utils/__init__.py
@@ -1,4 +1,5 @@
 """Contains utility functions."""
+
 from pkg_resources import get_distribution, packaging
 
 TORCH_VERSION = packaging.version.parse(get_distribution("torch").version)

--- a/backpack/utils/errors.py
+++ b/backpack/utils/errors.py
@@ -1,4 +1,5 @@
 """Contains errors for BackPACK."""
+
 from typing import Union
 from warnings import warn
 

--- a/backpack/utils/examples.py
+++ b/backpack/utils/examples.py
@@ -1,4 +1,5 @@
 """Utility functions for examples."""
+
 from typing import Iterator, List, Tuple
 
 from torch import Tensor, stack, zeros

--- a/backpack/utils/linear.py
+++ b/backpack/utils/linear.py
@@ -1,4 +1,5 @@
 """Contains utility functions to extract the GGN diagonal for linear layers."""
+
 from torch import Tensor, einsum
 from torch.nn import Linear
 

--- a/backpack/utils/module_classification.py
+++ b/backpack/utils/module_classification.py
@@ -1,4 +1,5 @@
 """Contains util function for classification of modules."""
+
 from torch.fx import GraphModule
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, Module, MSELoss, Sequential
 from torch.nn.modules.loss import _Loss

--- a/backpack/utils/subsampling.py
+++ b/backpack/utils/subsampling.py
@@ -1,4 +1,5 @@
 """Utility functions to enable mini-batch subsampling in extensions."""
+
 from typing import List
 
 from torch import Tensor

--- a/docs_src/examples/use_cases/example_batched_jacobians.py
+++ b/docs_src/examples/use_cases/example_batched_jacobians.py
@@ -26,6 +26,7 @@ We will use the batched vector-valued output of a simple MLP as tensor
 Let's start by importing the required functionality and write a setup function
 to create our synthetic data.
 """
+
 import itertools
 from math import sqrt
 from typing import List, Tuple

--- a/docs_src/examples/use_cases/example_resnet_all_in_one.py
+++ b/docs_src/examples/use_cases/example_resnet_all_in_one.py
@@ -1,6 +1,7 @@
 """Residual networks
 ====================
 """
+
 # %%
 # There are three different approaches to using BackPACK with ResNets.
 #

--- a/docs_src/examples/use_cases/example_rnn.py
+++ b/docs_src/examples/use_cases/example_rnn.py
@@ -1,6 +1,7 @@
 """Recurrent networks
 ====================
 """
+
 # %%
 # There are two different approaches to using BackPACK with RNNs.
 #

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 Use ``setup.cfg`` for configuration.
 """
+
 import sys
 
 from pkg_resources import VersionConflict, require

--- a/test/adaptive_avg_pool/problem.py
+++ b/test/adaptive_avg_pool/problem.py
@@ -1,4 +1,5 @@
 """Test problems for the AdaptiveAvgPool shape checker."""
+
 from __future__ import annotations
 
 import copy

--- a/test/adaptive_avg_pool/settings_adaptive_avg_pool_nd.py
+++ b/test/adaptive_avg_pool/settings_adaptive_avg_pool_nd.py
@@ -1,4 +1,5 @@
 """Settings to run test_adaptive_avg_pool_nd."""
+
 from typing import Any, Dict, List
 
 from torch import Size

--- a/test/adaptive_avg_pool/test_adaptive_avg_pool_nd.py
+++ b/test/adaptive_avg_pool/test_adaptive_avg_pool_nd.py
@@ -1,4 +1,5 @@
 """Test the shape checker of AdaptiveAvgPoolNDDerivatives."""
+
 from test.adaptive_avg_pool.problem import AdaptiveAvgPoolProblem, make_test_problems
 from test.adaptive_avg_pool.settings_adaptive_avg_pool_nd import SETTINGS
 from typing import List

--- a/test/conv2d_test.py
+++ b/test/conv2d_test.py
@@ -5,6 +5,7 @@ The example is taken from
     Chellapilla: High Performance Convolutional Neural Networks
     for Document Processing (2007).
 """
+
 from random import choice, randint
 
 import pytest

--- a/test/converter/converter_cases.py
+++ b/test/converter/converter_cases.py
@@ -7,6 +7,7 @@ Network with flatten operation
 Network with multiply operation
 Network with add operation
 """
+
 import abc
 from typing import List, Type
 

--- a/test/converter/resnet_cases.py
+++ b/test/converter/resnet_cases.py
@@ -1,4 +1,5 @@
 """Contains example ResNets to be used in tests."""
+
 from torch import flatten, tensor
 from torch.nn import (
     AdaptiveAvgPool2d,

--- a/test/converter/test_converter.py
+++ b/test/converter/test_converter.py
@@ -3,6 +3,7 @@
 - whether converted network is equivalent to original network
 - whether DiagGGN runs without errors on new network
 """
+
 from test.converter.converter_cases import CONVERTER_MODULES, ConverterModule
 from test.core.derivatives.utils import classification_targets, regression_targets
 from test.utils.skip_test import skip_torch_2_0_1_lstm

--- a/test/core/derivatives/__init__.py
+++ b/test/core/derivatives/__init__.py
@@ -1,4 +1,5 @@
 """Test functionality of `backpack.core.derivatives` module."""
+
 from torch.nn import (
     ELU,
     LSTM,

--- a/test/core/derivatives/batch_norm_settings.py
+++ b/test/core/derivatives/batch_norm_settings.py
@@ -12,6 +12,7 @@ Optional entries:
     "id_prefix" (str): Prefix to be included in the test name.
     "seed" (int): seed for the random number for torch.rand
 """
+
 from test.utils.evaluation_mode import initialize_batch_norm_eval
 
 from torch import rand

--- a/test/core/derivatives/derivatives_test.py
+++ b/test/core/derivatives/derivatives_test.py
@@ -112,9 +112,11 @@ def test_param_mjp(
                 print(f"testing with save_memory={save_memory}")
 
             mat = rand_mat_like_output(V, problem, subsampling=subsampling)
-            with weight_jac_t_save_memory(
-                save_memory=save_memory
-            ) if test_save_memory else nullcontext():
+            with (
+                weight_jac_t_save_memory(save_memory=save_memory)
+                if test_save_memory
+                else nullcontext()
+            ):
                 backpack_res = BackpackDerivatives(problem).param_mjp(
                     param_str, mat, sum_batch, subsampling=subsampling
                 )

--- a/test/core/derivatives/embedding_settings.py
+++ b/test/core/derivatives/embedding_settings.py
@@ -1,4 +1,5 @@
 """Settings for testing derivatives of Embedding."""
+
 from torch import randint
 from torch.nn import Embedding
 

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -1,4 +1,5 @@
 """Derivatives computed with PyTorch's autograd."""
+
 from test.core.derivatives.implementation.base import DerivativesImplementation
 from typing import List
 

--- a/test/core/derivatives/implementation/backpack.py
+++ b/test/core/derivatives/implementation/backpack.py
@@ -1,4 +1,5 @@
 """Contains derivative calculation with BackPACK."""
+
 from test.core.derivatives.implementation.base import DerivativesImplementation
 from test.utils import chunk_sizes
 from typing import List

--- a/test/core/derivatives/implementation/base.py
+++ b/test/core/derivatives/implementation/base.py
@@ -1,4 +1,5 @@
 """Contains DerivativesImplementation, the base class for autograd and backpack."""
+
 from abc import ABC, abstractmethod
 from typing import List
 

--- a/test/core/derivatives/scale_module_settings.py
+++ b/test/core/derivatives/scale_module_settings.py
@@ -1,4 +1,5 @@
 """Test settings for ScaleModule derivatives."""
+
 from torch import rand
 from torch.nn import Identity
 

--- a/test/core/derivatives/slicing_settings.py
+++ b/test/core/derivatives/slicing_settings.py
@@ -1,6 +1,5 @@
 """Contains test cases of BackPACK's custom Slicing module."""
 
-
 from torch import rand
 
 from backpack.custom_module.slicing import Slicing

--- a/test/core/derivatives/utils.py
+++ b/test/core/derivatives/utils.py
@@ -1,4 +1,5 @@
 """Utility functions to test `backpack.core.derivatives`."""
+
 from test.core.derivatives import derivatives_for
 from typing import Tuple, Type
 

--- a/test/extensions/automated_settings.py
+++ b/test/extensions/automated_settings.py
@@ -1,4 +1,5 @@
 """Contains helpers to create CNN test cases."""
+
 from test.core.derivatives.utils import classification_targets
 from typing import Any, Tuple, Type
 

--- a/test/extensions/firstorder/batch_grad/batch_grad_settings.py
+++ b/test/extensions/firstorder/batch_grad/batch_grad_settings.py
@@ -3,6 +3,7 @@
 The tests are taken from ``test.extensions.firstorder.firstorder_settings``,
 but additional custom tests can be defined here by appending it to the list.
 """
+
 from test.extensions.firstorder.firstorder_settings import FIRSTORDER_SETTINGS
 
 SHARED_SETTINGS = FIRSTORDER_SETTINGS

--- a/test/extensions/firstorder/batch_grad/test_batch_grad.py
+++ b/test/extensions/firstorder/batch_grad/test_batch_grad.py
@@ -1,4 +1,5 @@
 """Test BackPACK's ``BatchGrad`` extension."""
+
 from test.automated_test import check_sizes_and_values
 from test.extensions.firstorder.batch_grad.batch_grad_settings import (
     BATCH_GRAD_SETTINGS,

--- a/test/extensions/firstorder/batch_l2_grad/batchl2grad_settings.py
+++ b/test/extensions/firstorder/batch_l2_grad/batchl2grad_settings.py
@@ -3,6 +3,7 @@
 The tests are taken from `test.extensions.firstorder.firstorder_settings`, 
 but additional custom tests can be defined here by appending it to the list.
 """
+
 from test.extensions.firstorder.firstorder_settings import FIRSTORDER_SETTINGS
 
 SHARED_SETTINGS = FIRSTORDER_SETTINGS

--- a/test/extensions/firstorder/firstorder_settings.py
+++ b/test/extensions/firstorder/firstorder_settings.py
@@ -18,6 +18,7 @@ Optional entries:
     "id_prefix" (str): Prefix to be included in the test name.
     "seed" (int): seed set before initializing a case.
 """
+
 from test.core.derivatives.utils import classification_targets, regression_targets
 from test.extensions.automated_settings import make_simple_cnn_setting
 from test.utils.evaluation_mode import initialize_training_false_recursive

--- a/test/extensions/firstorder/sum_grad_squared/sumgradsquared_settings.py
+++ b/test/extensions/firstorder/sum_grad_squared/sumgradsquared_settings.py
@@ -3,6 +3,7 @@
 The tests are taken from `test.extensions.firstorder.firstorder_settings`, 
 but additional custom tests can be defined here by appending it to the list.
 """
+
 from test.core.derivatives.utils import classification_targets
 from test.extensions.firstorder.firstorder_settings import FIRSTORDER_SETTINGS
 

--- a/test/extensions/firstorder/sum_grad_squared/test_sumgradsquared.py
+++ b/test/extensions/firstorder/sum_grad_squared/test_sumgradsquared.py
@@ -6,6 +6,7 @@ Test individual gradients for the following layers:
 - sum of the square of batch gradients of convolutional layers
 
 """
+
 from test.automated_test import check_sizes_and_values
 from test.extensions.firstorder.sum_grad_squared.sumgradsquared_settings import (
     SUMGRADSQUARED_SETTINGS,

--- a/test/extensions/firstorder/variance/test_variance.py
+++ b/test/extensions/firstorder/variance/test_variance.py
@@ -1,4 +1,5 @@
 """Test BackPACK's ``Variance`` extension."""
+
 from test.automated_test import check_sizes_and_values
 from test.extensions.firstorder.variance.variance_settings import VARIANCE_SETTINGS
 from test.extensions.implementation.autograd import AutogradExtensions

--- a/test/extensions/firstorder/variance/variance_settings.py
+++ b/test/extensions/firstorder/variance/variance_settings.py
@@ -3,6 +3,7 @@
 Uses shared test cases from `test.extensions.firstorder.firstorder_settings`,
 and the local cases defined in this file.
 """
+
 from test.extensions.firstorder.firstorder_settings import FIRSTORDER_SETTINGS
 
 SHARED_SETTINGS = FIRSTORDER_SETTINGS

--- a/test/extensions/graph_clear_test.py
+++ b/test/extensions/graph_clear_test.py
@@ -1,4 +1,5 @@
 """Test whether the graph is clear after a backward pass."""
+
 from typing import Tuple
 
 from pytest import fixture

--- a/test/extensions/implementation/autograd.py
+++ b/test/extensions/implementation/autograd.py
@@ -1,4 +1,5 @@
 """Autograd implementation of BackPACK's extensions."""
+
 from math import isclose
 from test.extensions.implementation.base import ExtensionsImplementation
 from typing import Iterator, List, Union

--- a/test/extensions/implementation/backpack.py
+++ b/test/extensions/implementation/backpack.py
@@ -1,4 +1,5 @@
 """Extension implementations with BackPACK."""
+
 from test.extensions.implementation.base import ExtensionsImplementation
 from test.extensions.implementation.hooks import (
     BatchL2GradHook,

--- a/test/extensions/implementation/base.py
+++ b/test/extensions/implementation/base.py
@@ -1,4 +1,5 @@
 """Base class containing the functions to compare BackPACK and autograd."""
+
 from abc import ABC, abstractmethod
 from test.extensions.problem import ExtensionsTestProblem
 from typing import List, Union

--- a/test/extensions/secondorder/diag_ggn/diag_ggn_settings.py
+++ b/test/extensions/secondorder/diag_ggn/diag_ggn_settings.py
@@ -9,6 +9,7 @@ Includes
 Shared settings are taken from `test.extensions.secondorder.secondorder_settings`.
 Additional local cases can be defined here through ``LOCAL_SETTINGS``.
 """
+
 from test.converter.resnet_cases import ResNet1, ResNet2
 from test.core.derivatives.utils import classification_targets, regression_targets
 from test.extensions.secondorder.secondorder_settings import SECONDORDER_SETTINGS

--- a/test/extensions/secondorder/diag_ggn/test_batch_diag_ggn.py
+++ b/test/extensions/secondorder/diag_ggn/test_batch_diag_ggn.py
@@ -1,4 +1,5 @@
 """Test BatchDiagGGN extension."""
+
 from test.automated_test import check_sizes_and_values
 from test.extensions.implementation.autograd import AutogradExtensions
 from test.extensions.implementation.backpack import BackpackExtensions

--- a/test/extensions/secondorder/diag_ggn/test_diag_ggn.py
+++ b/test/extensions/secondorder/diag_ggn/test_diag_ggn.py
@@ -1,4 +1,5 @@
 """Test DiagGGN extension."""
+
 from test.automated_test import check_sizes_and_values
 from test.extensions.implementation.autograd import AutogradExtensions
 from test.extensions.implementation.backpack import BackpackExtensions

--- a/test/extensions/secondorder/hbp/test_kfac.py
+++ b/test/extensions/secondorder/hbp/test_kfac.py
@@ -1,4 +1,5 @@
 """Test BackPACK's KFAC extension."""
+
 from test.automated_test import check_sizes_and_values
 from test.extensions.implementation.autograd import AutogradExtensions
 from test.extensions.implementation.backpack import BackpackExtensions

--- a/test/extensions/secondorder/secondorder_settings.py
+++ b/test/extensions/secondorder/secondorder_settings.py
@@ -20,7 +20,6 @@ Optional entries:
     "seed" (int): seed for the random number for rand
 """
 
-
 from test.core.derivatives.utils import classification_targets, regression_targets
 from test.extensions.automated_settings import (
     make_simple_act_setting,

--- a/test/extensions/secondorder/sqrt_ggn/sqrt_ggn_settings.py
+++ b/test/extensions/secondorder/sqrt_ggn/sqrt_ggn_settings.py
@@ -1,4 +1,5 @@
 """Contains test settings for testing SqrtGGN extension."""
+
 from test.converter.resnet_cases import ResNet1, ResNet2
 from test.core.derivatives.utils import classification_targets, regression_targets
 from test.extensions.secondorder.secondorder_settings import SECONDORDER_SETTINGS

--- a/test/extensions/test_hooks.py
+++ b/test/extensions/test_hooks.py
@@ -3,6 +3,7 @@
 These tests aim at demonstrating the pitfalls one may run into when using hooks that
 iterate over ``module.parameters()``.
 """
+
 from test.core.derivatives.utils import classification_targets, get_available_devices
 from typing import Tuple
 

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -1,6 +1,7 @@
 """
 Test of the interface - calls every method that needs implementation
 """
+
 import pytest
 import torch
 from torch.nn import Conv2d, CrossEntropyLoss, Linear, ReLU, Sequential

--- a/test/test_batch_first.py
+++ b/test/test_batch_first.py
@@ -1,4 +1,5 @@
 """Tests whether batch axis is always first."""
+
 from pytest import raises
 
 from backpack.custom_module.permute import Permute

--- a/test/test_problems_activations.py
+++ b/test/test_problems_activations.py
@@ -17,23 +17,23 @@ TEST_PROBLEMS = {}
 
 for act_name, act_cls in ACTIVATIONS.items():
     for lin_name, lin_cls in LINEARS.items():
-        TEST_PROBLEMS[
-            "{}{}-regression".format(lin_name, act_name)
-        ] = make_regression_problem(
-            INPUT_SHAPE,
-            single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+        TEST_PROBLEMS["{}{}-regression".format(lin_name, act_name)] = (
+            make_regression_problem(
+                INPUT_SHAPE,
+                single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+            )
         )
 
-        TEST_PROBLEMS[
-            "{}{}-classification".format(lin_name, act_name)
-        ] = make_classification_problem(
-            INPUT_SHAPE,
-            single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+        TEST_PROBLEMS["{}{}-classification".format(lin_name, act_name)] = (
+            make_classification_problem(
+                INPUT_SHAPE,
+                single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+            )
         )
 
-        TEST_PROBLEMS[
-            "{}{}-2layer-classification".format(lin_name, act_name)
-        ] = make_classification_problem(
-            INPUT_SHAPE,
-            two_linear_layers(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+        TEST_PROBLEMS["{}{}-2layer-classification".format(lin_name, act_name)] = (
+            make_classification_problem(
+                INPUT_SHAPE,
+                two_linear_layers(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+            )
         )

--- a/test/test_problems_bn.py
+++ b/test/test_problems_bn.py
@@ -34,17 +34,18 @@ for lin_name, lin_cls in LINEARS.items():
         + [BatchNorm1d(TEST_SETTINGS["out_features"])],
     )
 
-    TEST_PROBLEMS[
-        "{}-bn-classification".format(lin_name)
-    ] = make_classification_problem(
-        INPUT_SHAPE,
-        single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=None)
-        + [bn_layer1()],
+    TEST_PROBLEMS["{}-bn-classification".format(lin_name)] = (
+        make_classification_problem(
+            INPUT_SHAPE,
+            single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=None)
+            + [bn_layer1()],
+        )
     )
 
-    TEST_PROBLEMS[
-        "{}-bn-2layer-classification".format(lin_name)
-    ] = make_classification_problem(
-        INPUT_SHAPE,
-        two_linear_layers(TEST_SETTINGS, lin_cls, activation_cls=None) + [bn_layer2()],
+    TEST_PROBLEMS["{}-bn-2layer-classification".format(lin_name)] = (
+        make_classification_problem(
+            INPUT_SHAPE,
+            two_linear_layers(TEST_SETTINGS, lin_cls, activation_cls=None)
+            + [bn_layer2()],
+        )
     )

--- a/test/test_problems_convolutions.py
+++ b/test/test_problems_convolutions.py
@@ -104,12 +104,12 @@ def make_2layer_classification_problem(conv_cls, act_cls):
 TEST_PROBLEMS = {}
 for conv_name, conv_cls in CONVS.items():
     for act_name, act_cls in ACTIVATIONS.items():
-        TEST_PROBLEMS[
-            "{}-{}-regression".format(conv_name, act_name)
-        ] = make_regression_problem(conv_cls, act_cls)
-        TEST_PROBLEMS[
-            "{}-{}-classification".format(conv_name, act_name)
-        ] = make_classification_problem(conv_cls, act_cls)
-        TEST_PROBLEMS[
-            "{}-{}-2layer-classification".format(conv_name, act_name)
-        ] = make_2layer_classification_problem(conv_cls, act_cls)
+        TEST_PROBLEMS["{}-{}-regression".format(conv_name, act_name)] = (
+            make_regression_problem(conv_cls, act_cls)
+        )
+        TEST_PROBLEMS["{}-{}-classification".format(conv_name, act_name)] = (
+            make_classification_problem(conv_cls, act_cls)
+        )
+        TEST_PROBLEMS["{}-{}-2layer-classification".format(conv_name, act_name)] = (
+            make_2layer_classification_problem(conv_cls, act_cls)
+        )

--- a/test/test_problems_kfacs.py
+++ b/test/test_problems_kfacs.py
@@ -17,11 +17,11 @@ assert TEST_SETTINGS["batch"] == 1
 REGRESSION_PROBLEMS = {}
 for act_name, act_cls in ACTIVATIONS.items():
     for lin_name, lin_cls in LINEARS.items():
-        REGRESSION_PROBLEMS[
-            "{}{}-regression".format(lin_name, act_name)
-        ] = make_regression_problem(
-            INPUT_SHAPE,
-            single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+        REGRESSION_PROBLEMS["{}{}-regression".format(lin_name, act_name)] = (
+            make_regression_problem(
+                INPUT_SHAPE,
+                single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+            )
         )
 
 TEST_PROBLEMS = {
@@ -29,16 +29,16 @@ TEST_PROBLEMS = {
 }
 for act_name, act_cls in ACTIVATIONS.items():
     for lin_name, lin_cls in LINEARS.items():
-        TEST_PROBLEMS[
-            "{}{}-classification".format(lin_name, act_name)
-        ] = make_classification_problem(
-            INPUT_SHAPE,
-            single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+        TEST_PROBLEMS["{}{}-classification".format(lin_name, act_name)] = (
+            make_classification_problem(
+                INPUT_SHAPE,
+                single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+            )
         )
 
-        TEST_PROBLEMS[
-            "{}{}-2layer-classification".format(lin_name, act_name)
-        ] = make_classification_problem(
-            INPUT_SHAPE,
-            two_linear_layers(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+        TEST_PROBLEMS["{}{}-2layer-classification".format(lin_name, act_name)] = (
+            make_classification_problem(
+                INPUT_SHAPE,
+                two_linear_layers(TEST_SETTINGS, lin_cls, activation_cls=act_cls),
+            )
         )

--- a/test/test_problems_linear.py
+++ b/test/test_problems_linear.py
@@ -24,8 +24,8 @@ for lin_name, lin_cls in LINEARS.items():
         INPUT_SHAPE, single_linear_layer(TEST_SETTINGS, lin_cls, activation_cls=None)
     )
 
-    TEST_PROBLEMS[
-        "{}-2layer-classification".format(lin_name)
-    ] = make_classification_problem(
-        INPUT_SHAPE, two_linear_layers(TEST_SETTINGS, lin_cls, activation_cls=None)
+    TEST_PROBLEMS["{}-2layer-classification".format(lin_name)] = (
+        make_classification_problem(
+            INPUT_SHAPE, two_linear_layers(TEST_SETTINGS, lin_cls, activation_cls=None)
+        )
     )

--- a/test/test_problems_padding.py
+++ b/test/test_problems_padding.py
@@ -54,6 +54,6 @@ def make_2layer_classification_problem(padding_cls):
 
 TEST_PROBLEMS = {}
 for pad_name, pad_cls in PADDINGS.items():
-    TEST_PROBLEMS[
-        "conv+{}-classification-2layer".format(pad_name)
-    ] = make_2layer_classification_problem(pad_cls)
+    TEST_PROBLEMS["conv+{}-classification-2layer".format(pad_name)] = (
+        make_2layer_classification_problem(pad_cls)
+    )

--- a/test/test_problems_pooling.py
+++ b/test/test_problems_pooling.py
@@ -85,9 +85,9 @@ for pool_name, pool_cls in POOLINGS.items():
     TEST_PROBLEMS["conv+{}-regression".format(pool_name)] = make_regression_problem(
         pool_cls
     )
-    TEST_PROBLEMS[
-        "conv+{}-classification".format(pool_name)
-    ] = make_classification_problem(pool_cls)
-    TEST_PROBLEMS[
-        "conv+{}-classification-2layer".format(pool_name)
-    ] = make_2layer_classification_problem(pool_cls)
+    TEST_PROBLEMS["conv+{}-classification".format(pool_name)] = (
+        make_classification_problem(pool_cls)
+    )
+    TEST_PROBLEMS["conv+{}-classification-2layer".format(pool_name)] = (
+        make_2layer_classification_problem(pool_cls)
+    )

--- a/test/test_retain_graph.py
+++ b/test/test_retain_graph.py
@@ -1,4 +1,5 @@
 """Test autograd functionality like retain_graph."""
+
 from test.automated_test import check_sizes_and_values
 
 from pytest import raises

--- a/test/utils/evaluation_mode.py
+++ b/test/utils/evaluation_mode.py
@@ -1,4 +1,5 @@
 """Tools for initializing in evaluation mode, especially BatchNorm."""
+
 from typing import Union
 
 from torch import rand_like

--- a/test/utils/test_conv_settings.py
+++ b/test/utils/test_conv_settings.py
@@ -14,6 +14,7 @@ Optional entries:
     "id_prefix" (str): Prefix to be included in the test name.
     "seed" (int): seed for the random number for torch.rand
 """
+
 import torch
 
 SETTINGS = []

--- a/test/utils/test_conv_transpose_settings.py
+++ b/test/utils/test_conv_transpose_settings.py
@@ -11,6 +11,7 @@ Optional entries:
     "id_prefix" (str): Prefix to be included in the test name.
     "seed" (int): seed for the random number for torch.rand
 """
+
 import torch
 
 SETTINGS = []


### PR DESCRIPTION
Fixes RTD build by specifying OS, applies latest `black` and `isort` to the code base.