### PR TITLE
[REF] Change HVP from backward-forward to double-backward

### DIFF
--- a/backpack/hessianfree/ggnvp.py
+++ b/backpack/hessianfree/ggnvp.py
@@ -53,6 +53,6 @@ def ggn_vector_product_from_plist(
         ``plist``.
     """
     Jv = R_op(output, plist, v)
-    HJv = hessian_vector_product(loss, output, Jv)
+    (HJv,) = hessian_vector_product(loss, [output], Jv)
     JTHJv = L_op(output, plist, HJv)
     return JTHJv

--- a/backpack/hessianfree/hvp.py
+++ b/backpack/hessianfree/hvp.py
@@ -32,7 +32,8 @@ def hessian_vector_product(
         Entries have same shape as entries of ``params`` and ``v``.
 
     Raises:
-        ValueError: If the length or shapes of ``params`` and ``v`` does not match.
+        ValueError: If the length or shapes of ``params``, ``v``, and ``grad_params``
+            do not match.
     """
     if grad_params is None:
         grad_params = grad(

--- a/backpack/hessianfree/hvp.py
+++ b/backpack/hessianfree/hvp.py
@@ -2,7 +2,6 @@
 
 from typing import Optional, Sequence, Tuple, Union
 
-import torch
 from torch import Tensor
 from torch.autograd import grad
 from torch.nn import Parameter
@@ -56,8 +55,6 @@ def hessian_vector_product(
         )
 
     gv = sum((g_i * v_i).sum() for g_i, v_i in zip(grad_params, v))
-    Hv = torch.autograd.grad(
-        gv, params, create_graph=True, retain_graph=True, materialize_grads=True
-    )
+    Hv = grad(gv, params, create_graph=True, retain_graph=True, materialize_grads=True)
 
     return tuple(j.detach() for j in Hv) if detach else Hv

--- a/backpack/hessianfree/hvp.py
+++ b/backpack/hessianfree/hvp.py
@@ -1,51 +1,63 @@
+"""Matrix-free multiplication with the Hessian."""
+
+from typing import Optional, Sequence, Tuple, Union
+
 import torch
+from torch import Tensor
+from torch.autograd import grad
+from torch.nn import Parameter
 
-from .rop import R_op
 
+def hessian_vector_product(
+    f: Tensor,
+    params: Sequence[Union[Tensor, Parameter]],
+    v: Sequence[Tensor],
+    grad_params: Optional[Sequence[Tensor]] = None,
+    detach: bool = True,
+) -> Tuple[Tensor, ...]:
+    """Multiply a vector ``v`` with the Hessian of ``f`` w.r.t. ``params``.
 
-def hessian_vector_product(f, params, v, grad_params=None, detach=True):
+    Args:
+        f: A scalar-valued tensor whose Hessian is multiplied onto the vector.
+        params: Parameters w.r.t. which the Hessian is computed.
+        v: Vector that is multiplied with the Hessian. Entries must have same shape
+            as the entries in ``params``.
+        grad_params: Pre-computed gradients of ``f`` w.r.t. ``params``. Useful if the
+            gradient is computed elsewhere. If provided, the first backward pass can be
+            avoided. Gradients must have been computed with ``create_graph=True``.
+            Entries must have same shape as the entries in ``params``.
+        detach: Whether to detach the Hessian-vector product from the computation graph.
+
+    Returns:
+        Hessian-vector product of ``f`` with respect to ``params`` applied to ``v``.
+        Entries have same shape as entries of ``params`` and ``v``.
+
+    Raises:
+        ValueError: If the length or shapes of ``params`` and ``v`` does not match.
     """
-    Multiplies the vector `v` with the Hessian,
-    `v = H @ v`
-
-    where `H` is the Hessian of `f` w.r.t. `params`.
-
-    Example usage:
-    ```
-    X, Y = data()
-    model = torch.nn.Linear(784, 10)
-    lossfunc = torch.nn.CrossEntropyLoss()
-
-    loss = lossfunc(output, Y)
-
-    v = list([torch.randn_like(p) for p in model.parameters])
-
-    Hv = hessian_vector_product(loss, list(model.parameters()), v)
-    ```
-
-    Parameters:
-    -----------
-        f: torch.Tensor
-        params: torch.Tensor or [torch.Tensor]
-        v: torch.Tensor or [torch.Tensor]
-            Shapes must match `params`
-        grad_params: torch.Tensor or [torch.Tensor], optional
-            Gradient of `f` w.r.t. `params`. If the gradients have already
-            been computed elsewhere, the first of two backpropagations can
-            be saved. `grad_params` must have been computed with
-            `create_graph = True` to not destroy the computation graph for
-            the second backward pass.
-        detach: Bool, optional
-            Whether to detach the output from the computation graph
-            (default: True)
-    """
-    if grad_params is not None:
-        df_dx = tuple(grad_params)
-    else:
-        df_dx = torch.autograd.grad(
+    if grad_params is None:
+        grad_params = grad(
             f, params, create_graph=True, retain_graph=True, materialize_grads=True
         )
 
-    Hv = R_op(df_dx, params, v)
+    if not len(grad_params) == len(params) == len(v):
+        raise ValueError(
+            f"Expected {len(params)} parameters, gradients, and vectors, "
+            f"but got {len(params)}, {len(grad_params)}, and {len(v)}."
+        )
+    if not all(
+        p_i.shape == v_i.shape == g_i.shape
+        for p_i, v_i, g_i in zip(params, v, grad_params)
+    ):
+        raise ValueError(
+            "Expected parameters, vectors, and gradients to have the same shape, "
+            f"but got {[p_i.shape for p_i in params]}, {[v_i.shape for v_i in v]}, "
+            f"and {[g_i.shape for g_i in grad_params]}."
+        )
+
+    gv = sum((g_i * v_i).sum() for g_i, v_i in zip(grad_params, v))
+    Hv = torch.autograd.grad(
+        gv, params, create_graph=True, retain_graph=True, materialize_grads=True
+    )
 
     return tuple(j.detach() for j in Hv) if detach else Hv

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added/New
+
+### Fixed/Removed
+
+### Internal
+
+- Improve efficiency of Hessian-vector product
+  ([PR](https://github.com/f-dangel/backpack/pull/341))
+
 ## [1.7.1] - 2024-11-15
 
 This patch extends the support of BackPACK's GGN-vector product to compute

--- a/fully_documented.txt
+++ b/fully_documented.txt
@@ -76,6 +76,7 @@ backpack/extensions/secondorder/hbp/conv_transpose3d.py
 backpack/extensions/secondorder/hbp/conv_transposend.py
 
 backpack/hessianfree/ggnvp.py
+backpack/hessianfree/hvp.py
 
 backpack/utils/linear.py
 backpack/utils/subsampling.py

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -235,8 +235,8 @@ class AutogradDerivatives(DerivativesImplementation):
         `hessian[a, b, c]` contains the Hessian of the scalar entry `tensor[a, b, c]`
         w.r.t. `x[a, b, c]`.
 
-        If ``tensor`` is linear in ``x``, autograd raises a ``RuntimeError``.
-        In that case, a Hessian of zeros is created manually and returned.
+        If ``x`` is not of floating dtype, it cannot be differentiated and the returned
+        Hessian will be zero.
 
         Arguments:
             tensor: An arbitrary tensor.
@@ -249,6 +249,7 @@ class AutogradDerivatives(DerivativesImplementation):
             try:
                 yield self._hessian(t, x)
             except RuntimeError:
+                assert not x.is_floating_point()
                 yield zeros(*x.shape, *x.shape, device=x.device, dtype=x.dtype)
 
     def hessian_is_zero(self) -> bool:  # noqa: D102

--- a/test/core/derivatives/implementation/autograd.py
+++ b/test/core/derivatives/implementation/autograd.py
@@ -235,8 +235,8 @@ class AutogradDerivatives(DerivativesImplementation):
         `hessian[a, b, c]` contains the Hessian of the scalar entry `tensor[a, b, c]`
         w.r.t. `x[a, b, c]`.
 
-        If ``x`` is not of floating dtype, it cannot be differentiated and the returned
-        Hessian will be zero.
+        If ``tensor`` is linear in ``x``, autograd raises a ``RuntimeError``.
+        In that case, a Hessian of zeros is created manually and returned.
 
         Arguments:
             tensor: An arbitrary tensor.
@@ -249,7 +249,6 @@ class AutogradDerivatives(DerivativesImplementation):
             try:
                 yield self._hessian(t, x)
             except RuntimeError:
-                assert not x.is_floating_point()
                 yield zeros(*x.shape, *x.shape, device=x.device, dtype=x.dtype)
 
     def hessian_is_zero(self) -> bool:  # noqa: D102

--- a/test/implementation/implementation_autograd.py
+++ b/test/implementation/implementation_autograd.py
@@ -132,7 +132,7 @@ class AutogradImpl(Implementation):
     def hvp_applied_columnwise(self, f, p, mat):
         h_cols = []
         for i in range(mat.size(0)):
-            hvp_col_i = hessian_vector_product(f, [p], mat[i, :])[0]
+            (hvp_col_i,) = hessian_vector_product(f, [p], [mat[i, :]])
             h_cols.append(hvp_col_i.unsqueeze(0))
 
         return torch.cat(h_cols, dim=0)
@@ -172,7 +172,7 @@ class AutogradImpl(Implementation):
         ggn_cols = []
         for i in range(mat.size(0)):
             col_i = mat[i, :]
-            GGN_col_i = ggn_vector_product_from_plist(loss, out, [p], col_i)[0]
+            (GGN_col_i,) = ggn_vector_product_from_plist(loss, out, [p], [col_i])
             ggn_cols.append(GGN_col_i.unsqueeze(0))
 
         return torch.cat(ggn_cols, dim=0)


### PR DESCRIPTION
This PR improves the Hessian-vector product's run time and memory consumption.

The old approach was using a JVP(VJP) approach, i.e. backward-forward.
The new approach uses a VJP(VJP) approach, i.e. backward-backward, which is more efficient according to my measurements (on a CPU roughly 2x faster, 20% less memory, see below).

The following script benchmarks an HVP on `resnet18` with ImageNet-shaped synthetic data:
```python
"""Benchmark BackPACK's Hessian-vector product."""

from time import perf_counter

import numpy
from memory_profiler import memory_usage
from torch import cuda, device, manual_seed, rand, rand_like, randint
from torch.nn import CrossEntropyLoss
from torchvision.models import resnet18

from backpack.hessianfree.hvp import hessian_vector_product


def hvp():
    # setup
    manual_seed(0)
    dev = device("cuda" if cuda.is_available() else "cpu")
    N = 16
    X = rand(N, 3, 224, 224, device=dev)
    y = randint(0, 1000, (N,), device=dev)

    model = resnet18().to(dev)
    loss_func = CrossEntropyLoss().to(dev)

    params = [p for p in model.parameters() if p.requires_grad]
    v = [rand_like(p) for p in params]
    loss = loss_func(model(X), y)

    # compute HVP
    start = perf_counter()
    if cuda.is_available():
        cuda.synchronize()
    _ = hessian_vector_product(loss, params, v)
    if cuda.is_available():
        cuda.synchronize()
    end = perf_counter()

    return end - start


if __name__ == "__main__":
    num_repeats = 10
    peakmems_gib, times_s = [], []

    for n in range(num_repeats):
        m_mib, t_s = memory_usage(hvp, interval=1e-3, max_usage=True, retval=True)
        m_gib = m_mib / 2**10
        peakmems_gib.append(m_gib)
        times_s.append(t_s)

        print(f"Iteration {n}")
        print(f"\tPeak memory: {m_gib:.2f} GiB")
        print(f"\tHVP time: {t_s:.3f} s")

    # compute mean and standard deviation
    peakmem_mean, peakmem_std = numpy.mean(peakmems_gib), numpy.std(peakmems_gib)
    time_mean, time_std = numpy.mean(times_s), numpy.std(times_s)

    print(f"Peak memory: {peakmem_mean:.2f} ± {peakmem_std:.2f} GiB ")
    print(f"HVP time: {time_mean:.3f} ± {time_std:.3f} s")
```
On my M2 MacBook, the old approach is slower than the new approach.

Using the old approach:
```bash
Iteration 0
        Peak memory: 4.53 GiB
        HVP time: 9.959 s
Iteration 1
        Peak memory: 5.31 GiB
        HVP time: 9.037 s
Iteration 2
        Peak memory: 5.20 GiB
        HVP time: 9.346 s
Iteration 3
        Peak memory: 5.11 GiB
        HVP time: 9.583 s
Iteration 4
        Peak memory: 4.88 GiB
        HVP time: 9.795 s
Iteration 5
        Peak memory: 4.49 GiB
        HVP time: 9.875 s
Iteration 6
        Peak memory: 4.98 GiB
        HVP time: 9.241 s
Iteration 7
        Peak memory: 4.94 GiB
        HVP time: 9.672 s
Iteration 8
        Peak memory: 5.03 GiB
        HVP time: 9.642 s
Iteration 9
        Peak memory: 5.01 GiB
        HVP time: 9.743 s
Peak memory: 4.95 ± 0.25 GiB
HVP time: 9.589 ± 0.279 s
```
Using the new approach:
```bash
Iteration 0
        Peak memory: 3.62 GiB
        HVP time: 4.410 s
Iteration 1
        Peak memory: 4.01 GiB
        HVP time: 4.271 s
Iteration 2
        Peak memory: 4.04 GiB
        HVP time: 4.515 s
Iteration 3
        Peak memory: 4.04 GiB
        HVP time: 4.297 s
Iteration 4
        Peak memory: 4.05 GiB
        HVP time: 5.025 s
Iteration 5
        Peak memory: 3.88 GiB
        HVP time: 4.365 s
Iteration 6
        Peak memory: 3.92 GiB
        HVP time: 4.346 s
Iteration 7
        Peak memory: 3.93 GiB
        HVP time: 4.330 s
Iteration 8
        Peak memory: 3.92 GiB
        HVP time: 4.367 s
Iteration 9
        Peak memory: 3.87 GiB
        HVP time: 4.419 s
Peak memory: 3.93 ± 0.12 GiB
HVP time: 4.434 ± 0.207 s
```