### PR TITLE
[OPT] Avoid keeping differentiable graph if `detach=True`

### DIFF
--- a/backpack/hessianfree/hvp.py
+++ b/backpack/hessianfree/hvp.py
@@ -56,6 +56,12 @@ def hessian_vector_product(
         )
 
     gv = sum((g_i * v_i).sum() for g_i, v_i in zip(grad_params, v))
-    Hv = grad(gv, params, create_graph=True, retain_graph=True, materialize_grads=True)
+    Hv = grad(
+        gv,
+        params,
+        create_graph=not detach,
+        retain_graph=True,
+        materialize_grads=True,
+    )
 
     return tuple(j.detach() for j in Hv) if detach else Hv

--- a/backpack/hessianfree/lop.py
+++ b/backpack/hessianfree/lop.py
@@ -9,7 +9,7 @@ def L_op(ys, xs, ws, retain_graph=True, detach=True):
         ys,
         xs,
         grad_outputs=ws,
-        create_graph=True,
+        create_graph=not detach,
         retain_graph=retain_graph,
         allow_unused=True,
         materialize_grads=True,

--- a/backpack/hessianfree/rop.py
+++ b/backpack/hessianfree/rop.py
@@ -24,7 +24,7 @@ def R_op(ys, xs, vs, retain_graph=True, detach=True):
         gs,
         ws,
         grad_outputs=vs,
-        create_graph=True,
+        create_graph=not detach,
         retain_graph=True,
         allow_unused=True,
         materialize_grads=True,


### PR DESCRIPTION
This optimization improves BackPACK's JVPs, HVPs, and GGNVPs whenever `detach=True` by setting `create_graph=False`, which will immediately discard the associated compute graph, instead of discarding it when the computation results are detached. This reduces peak memory.